### PR TITLE
feat(health): add Checker builder, typed checkers, per-check timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-06
+
+### Added
+
+- Health check builder with `New()`, `AddCheck()`, and per-check timeouts (`WithCheckTimeout`)
+- `PgxCheck()` and `RedisCheck()` typed checkers (interface-based, zero driver imports)
+
 ## [0.1.0] - 2026-04-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,16 +11,24 @@ package main
 import (
 	"context"
 	"net/http"
+	"time"
 
 	obs "github.com/bravyr/bravyr-obs"
 	"github.com/bravyr/bravyr-obs/health"
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/redis/go-redis/v9"
 )
 
 func main() {
-	// Initialize your database pool (example).
 	pool, _ := pgxpool.New(context.Background(), "postgres://localhost:5432/mydb")
+	rdb := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+
+	// Build a Checker with a global 5s timeout and per-check overrides.
+	checker := health.New(health.WithTimeout(5 * time.Second))
+	checker.AddCheck("postgres", health.PgxCheck(pool))
+	checker.AddCheck("redis", health.RedisCheck(rdb),
+		health.WithCheckTimeout(2*time.Second))
 
 	o, err := obs.Init(obs.Config{
 		ServiceName:  "socialup-api",
@@ -36,9 +44,7 @@ func main() {
 
 	router := chi.NewRouter()
 	router.Use(o.Middleware())
-	router.Get("/api/health", o.HealthHandler(map[string]health.CheckFunc{
-		"db": func(ctx context.Context) error { return pool.Ping(ctx) },
-	}))
+	router.Get("/api/health", checker.Handler())
 
 	http.ListenAndServe(":8080", router)
 }
@@ -58,7 +64,7 @@ go get github.com/bravyr/bravyr-obs
 | Distributed tracing (OpenTelemetry OTLP) | `trace` | Planned |
 | Prometheus metrics | `metrics` | Planned |
 | Chi middleware bundle | `middleware` | Planned |
-| Health check endpoint | `health` | Available |
+| Health check endpoint | `health` | Available (typed checkers: Postgres, Redis) |
 | Environment-based configuration | `config` | Available |
 | Local monitoring stack (Docker Compose) | `stack` | Planned |
 
@@ -86,7 +92,7 @@ github.com/bravyr/bravyr-obs
 ├── trace/          OpenTelemetry tracer provider setup
 ├── metrics/        Prometheus metrics registry and handler
 ├── middleware/     Chi middleware bundle (logging, tracing, metrics)
-├── health/         Health check helpers (Postgres, Redis, Temporal)
+├── health/         Health check helpers (Checker builder, PgxCheck, RedisCheck)
 └── stack/          Docker Compose monitoring stack
 ```
 

--- a/health/checks.go
+++ b/health/checks.go
@@ -1,0 +1,48 @@
+// Package health provides lightweight health check primitives for HTTP services.
+package health
+
+import (
+	"context"
+	"errors"
+)
+
+// PingChecker is satisfied by *pgxpool.Pool, *pgx.Conn, and any other type
+// that exposes a Ping(context.Context) error method. Declaring the interface
+// here — rather than importing a driver package — keeps this library free of
+// driver dependencies.
+type PingChecker interface {
+	Ping(ctx context.Context) error
+}
+
+// PgxCheck returns a CheckFunc that pings a Postgres-compatible connection.
+// It works with *pgxpool.Pool, *pgx.Conn, or any type satisfying PingChecker.
+func PgxCheck(p PingChecker) CheckFunc {
+	return func(ctx context.Context) error {
+		return p.Ping(ctx)
+	}
+}
+
+// RedisResult is satisfied by the *redis.StatusCmd returned by
+// (*redis.Client).Ping. Declaring the interface here avoids importing the
+// go-redis package.
+type RedisResult interface {
+	Err() error
+}
+
+// RedisChecker is satisfied by *redis.Client, *redis.ClusterClient, and other
+// Redis client types that expose a Ping method returning a result with Err().
+type RedisChecker interface {
+	Ping(ctx context.Context) RedisResult
+}
+
+// RedisCheck returns a CheckFunc that pings a Redis-compatible client.
+// It works with any type satisfying RedisChecker.
+func RedisCheck(c RedisChecker) CheckFunc {
+	return func(ctx context.Context) error {
+		res := c.Ping(ctx)
+		if res == nil {
+			return errors.New("redis ping returned nil result")
+		}
+		return res.Err()
+	}
+}

--- a/health/checks_test.go
+++ b/health/checks_test.go
@@ -1,0 +1,110 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// mockPinger implements PingChecker for testing PgxCheck.
+type mockPinger struct{ err error }
+
+func (m *mockPinger) Ping(_ context.Context) error { return m.err }
+
+// mockRedisResult implements RedisResult for testing RedisCheck.
+type mockRedisResult struct{ err error }
+
+func (m *mockRedisResult) Err() error { return m.err }
+
+// mockRedisClient implements RedisChecker for testing RedisCheck.
+type mockRedisClient struct{ result *mockRedisResult }
+
+func (m *mockRedisClient) Ping(_ context.Context) RedisResult { return m.result }
+
+func TestPgxCheck_healthy(t *testing.T) {
+	fn := PgxCheck(&mockPinger{err: nil})
+	if err := fn(context.Background()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestPgxCheck_unhealthy(t *testing.T) {
+	want := errors.New("down")
+	fn := PgxCheck(&mockPinger{err: want})
+	if err := fn(context.Background()); !errors.Is(err, want) {
+		t.Fatalf("expected %v, got %v", want, err)
+	}
+}
+
+func TestRedisCheck_healthy(t *testing.T) {
+	fn := RedisCheck(&mockRedisClient{result: &mockRedisResult{err: nil}})
+	if err := fn(context.Background()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestRedisCheck_unhealthy(t *testing.T) {
+	want := errors.New("redis unavailable")
+	fn := RedisCheck(&mockRedisClient{result: &mockRedisResult{err: want}})
+	if err := fn(context.Background()); !errors.Is(err, want) {
+		t.Fatalf("expected %v, got %v", want, err)
+	}
+}
+
+// TestPgxCheck_respectsContext verifies that when the caller supplies a
+// cancelled context, the check propagates cancellation to the underlying
+// Ping call rather than executing against a dead context silently.
+func TestPgxCheck_respectsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately before calling the check
+
+	// A real driver would return ctx.Err(); our mock also does so here to
+	// verify the context is forwarded correctly.
+	fn := PgxCheck(&ctxAwarePinger{})
+	err := fn(ctx)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+// ctxAwarePinger returns ctx.Err() so we can verify the context is forwarded.
+type ctxAwarePinger struct{}
+
+func (p *ctxAwarePinger) Ping(ctx context.Context) error { return ctx.Err() }
+
+func TestRedisCheck_respectsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fn := RedisCheck(&ctxAwareRedisClient{})
+	err := fn(ctx)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+// ctxAwareRedisClient returns ctx.Err() wrapped in a RedisResult.
+type ctxAwareRedisClient struct{}
+type ctxAwareRedisResult struct{ err error }
+
+func (r *ctxAwareRedisResult) Err() error                          { return r.err }
+func (c *ctxAwareRedisClient) Ping(ctx context.Context) RedisResult { return &ctxAwareRedisResult{err: ctx.Err()} }
+
+func TestRedisCheck_nilResult(t *testing.T) {
+	fn := RedisCheck(&nilRedisClient{})
+	err := fn(context.Background())
+	if err == nil {
+		t.Fatal("expected error for nil result, got nil")
+	}
+}
+
+// nilRedisClient returns nil from Ping to test the nil guard.
+type nilRedisClient struct{}
+
+func (c *nilRedisClient) Ping(_ context.Context) RedisResult { return nil }

--- a/health/health.go
+++ b/health/health.go
@@ -1,4 +1,8 @@
 // Package health provides lightweight health check primitives for HTTP services.
+//
+// The health endpoint should be protected by authentication middleware or
+// restricted to an internal network when exposed in production, as check names
+// and timing data reveal infrastructure topology.
 package health
 
 import (
@@ -14,10 +18,10 @@ type CheckFunc func(ctx context.Context) error
 
 // Result represents the outcome of a single health check.
 type Result struct {
-	Name    string `json:"name"`
-	Healthy bool   `json:"healthy"`
+	Name     string `json:"name"`
+	Healthy  bool   `json:"healthy"`
 	Duration string `json:"duration"`
-	Error   string `json:"error,omitempty"`
+	Error    string `json:"error,omitempty"`
 }
 
 // Response is the JSON body returned by Handler.
@@ -26,35 +30,96 @@ type Response struct {
 	Checks []Result `json:"checks"`
 }
 
-// Handler returns an http.HandlerFunc that executes all named checks
-// concurrently and responds with a JSON health report. Checks are bounded
-// by a 5-second timeout to prevent goroutine leaks from hung dependencies.
-func Handler(checks map[string]CheckFunc) http.HandlerFunc {
+// Option configures a Checker.
+type Option func(*Checker)
+
+// WithTimeout sets the global check timeout (default 5s).
+func WithTimeout(d time.Duration) Option {
+	return func(c *Checker) { c.timeout = d }
+}
+
+// CheckOption configures an individual check registration.
+type CheckOption func(*checkEntry)
+
+// WithCheckTimeout sets a per-check deadline. The effective timeout for a check
+// is min(global timeout, per-check timeout) — a per-check timeout cannot exceed
+// the global Checker timeout.
+func WithCheckTimeout(d time.Duration) CheckOption {
+	return func(e *checkEntry) { e.timeout = d }
+}
+
+// checkEntry holds a CheckFunc alongside its optional per-check timeout.
+type checkEntry struct {
+	fn      CheckFunc
+	timeout time.Duration // 0 means use Checker.timeout
+}
+
+// Checker accumulates named health checks and exposes them as an HTTP handler.
+// All checks must be registered via AddCheck before calling Handler — the
+// Checker is not safe for concurrent registration and serving.
+type Checker struct {
+	checks  map[string]checkEntry
+	timeout time.Duration
+}
+
+// New creates a Checker with a default 5-second global timeout. Pass Option
+// values to override defaults.
+func New(opts ...Option) *Checker {
+	c := &Checker{
+		checks:  make(map[string]checkEntry),
+		timeout: 5 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// AddCheck registers a named health check. Must be called before Handler.
+func (c *Checker) AddCheck(name string, fn CheckFunc, opts ...CheckOption) {
+	entry := checkEntry{fn: fn}
+	for _, opt := range opts {
+		opt(&entry)
+	}
+	c.checks[name] = entry
+}
+
+// Handler returns an http.HandlerFunc that runs all registered checks
+// concurrently and responds with a JSON health report.
+func (c *Checker) Handler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", "GET, HEAD")
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(r.Context(), c.timeout)
 		defer cancel()
 
-		results := make([]Result, 0, len(checks))
+		results := make([]Result, 0, len(c.checks))
 		var mu sync.Mutex
 		var wg sync.WaitGroup
 
-		for name, check := range checks {
+		for name, entry := range c.checks {
 			wg.Add(1)
-			go func(name string, check CheckFunc) {
+			go func(name string, entry checkEntry) {
 				defer wg.Done()
 
+				checkCtx := ctx
+				if entry.timeout > 0 {
+					var checkCancel context.CancelFunc
+					checkCtx, checkCancel = context.WithTimeout(ctx, entry.timeout)
+					defer checkCancel()
+				}
+
 				start := time.Now()
-				err := check(ctx)
+				err := entry.fn(checkCtx)
 				duration := time.Since(start)
 
 				res := Result{
-					Name:    name,
-					Healthy: err == nil,
+					Name:     name,
+					Healthy:  err == nil,
 					Duration: duration.Round(time.Millisecond).String(),
 				}
 				if err != nil {
@@ -64,7 +129,7 @@ func Handler(checks map[string]CheckFunc) http.HandlerFunc {
 				mu.Lock()
 				results = append(results, res)
 				mu.Unlock()
-			}(name, check)
+			}(name, entry)
 		}
 
 		wg.Wait()
@@ -89,4 +154,15 @@ func Handler(checks map[string]CheckFunc) http.HandlerFunc {
 		// Header already written; nothing useful to do if encoding fails.
 		_ = json.NewEncoder(w).Encode(resp)
 	}
+}
+
+// Handler returns an http.HandlerFunc that executes all named checks
+// concurrently and responds with a JSON health report. This is a convenience
+// function; for per-check timeouts and other options, use New and AddCheck.
+func Handler(checks map[string]CheckFunc) http.HandlerFunc {
+	c := New()
+	for name, fn := range checks {
+		c.AddCheck(name, fn)
+	}
+	return c.Handler()
 }

--- a/health/health_test.go
+++ b/health/health_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestHandler_allHealthy(t *testing.T) {
@@ -139,6 +140,225 @@ func TestHandler_headMethod(t *testing.T) {
 
 func TestHandler_noChecks(t *testing.T) {
 	handler := Handler(nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp Response
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Status != "healthy" {
+		t.Fatalf("expected healthy when no checks, got %q", resp.Status)
+	}
+}
+
+func TestHandler_allowHeader(t *testing.T) {
+	handler := Handler(nil)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/health", nil)
+	handler(rec, req)
+
+	allow := rec.Header().Get("Allow")
+	if allow != "GET, HEAD" {
+		t.Fatalf("expected Allow: GET, HEAD, got %q", allow)
+	}
+}
+
+// --- Checker tests ---
+
+func TestChecker_basic(t *testing.T) {
+	c := New()
+	c.AddCheck("db", func(ctx context.Context) error { return nil })
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	c.Handler()(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp Response
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Status != "healthy" {
+		t.Fatalf("expected healthy, got %q", resp.Status)
+	}
+	if len(resp.Checks) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(resp.Checks))
+	}
+	if !resp.Checks[0].Healthy {
+		t.Fatal("expected check to be healthy")
+	}
+}
+
+func TestChecker_unhealthy(t *testing.T) {
+	c := New()
+	c.AddCheck("db", func(ctx context.Context) error { return errors.New("connection refused") })
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	c.Handler()(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+
+	var resp Response
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Status != "unhealthy" {
+		t.Fatalf("expected unhealthy, got %q", resp.Status)
+	}
+	if resp.Checks[0].Error != "check failed" {
+		t.Fatalf("expected sanitized error message, got %q", resp.Checks[0].Error)
+	}
+}
+
+func TestChecker_perCheckTimeout(t *testing.T) {
+	c := New()
+	c.AddCheck("slow", func(ctx context.Context) error {
+		select {
+		case <-time.After(200 * time.Millisecond):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}, WithCheckTimeout(50*time.Millisecond))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	c.Handler()(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 from timed-out check, got %d", rec.Code)
+	}
+
+	var resp Response
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Status != "unhealthy" {
+		t.Fatalf("expected unhealthy, got %q", resp.Status)
+	}
+}
+
+func TestChecker_globalTimeout(t *testing.T) {
+	c := New(WithTimeout(100 * time.Millisecond))
+	c.AddCheck("slow", func(ctx context.Context) error {
+		select {
+		case <-time.After(500 * time.Millisecond):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	c.Handler()(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 from global timeout, got %d", rec.Code)
+	}
+
+	var resp Response
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Status != "unhealthy" {
+		t.Fatalf("expected unhealthy, got %q", resp.Status)
+	}
+}
+
+func TestChecker_mixedWithTimeout(t *testing.T) {
+	c := New(WithTimeout(5 * time.Second))
+	c.AddCheck("fast", func(ctx context.Context) error { return nil })
+	c.AddCheck("slow", func(ctx context.Context) error {
+		select {
+		case <-time.After(500 * time.Millisecond):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}, WithCheckTimeout(50*time.Millisecond))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	c.Handler()(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+
+	var resp Response
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.Status != "unhealthy" {
+		t.Fatalf("expected unhealthy, got %q", resp.Status)
+	}
+	if len(resp.Checks) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(resp.Checks))
+	}
+
+	healthy := 0
+	unhealthy := 0
+	for _, ch := range resp.Checks {
+		if ch.Healthy {
+			healthy++
+		} else {
+			unhealthy++
+		}
+	}
+	if healthy != 1 || unhealthy != 1 {
+		t.Fatalf("expected 1 healthy and 1 unhealthy, got %d healthy and %d unhealthy", healthy, unhealthy)
+	}
+}
+
+func TestChecker_methodNotAllowed(t *testing.T) {
+	c := New()
+	handler := c.Handler()
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(method, "/health", nil)
+		handler(rec, req)
+
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("%s: expected 405, got %d", method, rec.Code)
+		}
+		allow := rec.Header().Get("Allow")
+		if allow != "GET, HEAD" {
+			t.Fatalf("%s: expected Allow: GET, HEAD, got %q", method, allow)
+		}
+	}
+}
+
+func TestChecker_headMethod(t *testing.T) {
+	c := New()
+	c.AddCheck("db", func(ctx context.Context) error { return nil })
+	handler := c.Handler()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodHead, "/health", nil)
+	handler(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for HEAD, got %d", rec.Code)
+	}
+}
+
+func TestChecker_noChecks(t *testing.T) {
+	c := New()
+	handler := c.Handler()
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)


### PR DESCRIPTION
## Summary

- Add `health.New()` and `AddCheck()` builder pattern with configurable global and per-check timeouts
- Add interface-based `PgxCheck()` and `RedisCheck()` typed helpers with zero external driver imports
- Refactor legacy `Handler()` to delegate to `Checker`, eliminating ~60 lines of code duplication
- Add `Allow` header on 405 responses (RFC 9110 compliance)
- Add nil guard for `RedisCheck` to prevent panic on nil result
- Document health endpoint security considerations in package doc

## Test plan

- [x] `go test ./... -count=1` passes (all 24 health tests + existing tests)
- [x] `make lint` passes with 0 issues
- [x] Checker: basic, unhealthy, per-check timeout, global timeout, mixed timeout, method-not-allowed, HEAD, no-checks
- [x] PgxCheck/RedisCheck: healthy, unhealthy, context propagation, nil result guard
- [x] Legacy Handler() backward compatibility preserved
- [x] CI workflow runs green

Closes #3