### PR TITLE
feat(log): add structured logging with zerolog and Seq CLEF sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Health check builder with `New()`, `AddCheck()`, and per-check timeouts (`WithCheckTimeout`)
 - `PgxCheck()` and `RedisCheck()` typed checkers (interface-based, zero driver imports)
+- Structured logging with zerolog (`log` package): `Logger` type with `Debug()`, `Info()`, `Warn()`, `Error()`, `Fatal()`, `With()`, and `Shutdown()`
+- Seq CLEF HTTP async sink: batching up to 100 events per POST, 500 ms flush interval, channel buffer of 1024, dropped-event and send-failure counters
+- Seq TLS enforcement: minimum TLS 1.2 on the HTTP client used for log shipping
+- `obs.Obs.Logger()` accessor to expose the structured logger to callers
+- `Config.Validate()` rejects `SeqURL` that does not start with `https://` when `DevMode` is false
+- `Config.Validate()` rejects `DevMode=true` when `Environment` is `"production"` (case-insensitive)
 
 ## [0.1.0] - 2026-04-06
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,54 @@ func main() {
 }
 ```
 
+## Logging
+
+`obs.Init()` constructs a zerolog-based structured logger automatically. Access
+it via `o.Logger()`:
+
+```go
+o, err := obs.Init(obs.Config{
+    ServiceName: "my-api",
+    Environment: "production",
+    LogLevel:    "info",
+    SeqURL:      "https://seq.internal:5341",
+    SeqAPIKey:   os.Getenv("SEQ_API_KEY"),
+})
+if err != nil {
+    panic(err)
+}
+defer o.Shutdown(context.Background())
+
+log := o.Logger()
+log.Info().Str("version", "1.0.0").Msg("service started")
+log.Error().Err(err).Str("user_id", uid).Msg("database query failed")
+
+// Derive a request-scoped sub-logger with fixed fields.
+reqLog := log.With().Str("request_id", reqID).Logger()
+reqLog.Info().Msg("handling request")
+```
+
+### Logging configuration
+
+| Behaviour | Config |
+|---|---|
+| Human-readable console output | `DevMode: true` (development only) |
+| Ship logs to Seq | Set `SeqURL` (must be `https://` in non-dev mode) |
+| Authenticate to Seq | Set `SeqAPIKey` |
+| Minimum log level | `LogLevel: "debug"` / `"info"` / `"warn"` / `"error"` / `"fatal"` |
+
+The `log` package can also be used standalone without the root facade:
+
+```go
+import obslog "github.com/bravyr/bravyr-obs/log"
+
+logger, err := obslog.New(obslog.Config{
+    ServiceName: "worker",
+    Level:       "debug",
+    DevMode:     true,
+})
+```
+
 ## Installation
 
 ```bash
@@ -60,7 +108,7 @@ go get github.com/bravyr/bravyr-obs
 
 | Feature | Package | Status |
 |---|---|---|
-| Structured logging (zerolog + Seq CLEF) | `log` | Planned |
+| Structured logging (zerolog + Seq CLEF) | `log` | Available |
 | Distributed tracing (OpenTelemetry OTLP) | `trace` | Planned |
 | Prometheus metrics | `metrics` | Planned |
 | Chi middleware bundle | `middleware` | Planned |

--- a/config/config.go
+++ b/config/config.go
@@ -30,11 +30,19 @@ func (c Config) Validate() error {
 	}
 
 	validLevels := map[string]bool{
-		"trace": true, "debug": true, "info": true,
-		"warn": true, "error": true, "fatal": true, "panic": true,
+		"debug": true, "info": true,
+		"warn": true, "error": true, "fatal": true,
 	}
 	if !validLevels[strings.ToLower(c.LogLevel)] {
 		errs = append(errs, fmt.Errorf("LogLevel %q is not valid", c.LogLevel))
+	}
+
+	if c.SeqURL != "" && !c.DevMode && !strings.HasPrefix(c.SeqURL, "https://") {
+		errs = append(errs, fmt.Errorf("SeqURL must use https:// in non-dev mode, got %q", c.SeqURL))
+	}
+
+	if c.DevMode && strings.EqualFold(c.Environment, "production") {
+		errs = append(errs, errors.New("DevMode must not be enabled in production environment"))
 	}
 
 	return errors.Join(errs...)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -119,3 +119,87 @@ func TestMarshalJSON_emptyAPIKey(t *testing.T) {
 		t.Fatal("MarshalJSON should not show *** when API key is empty")
 	}
 }
+
+func TestValidate_seqURLRequiresHTTPS(t *testing.T) {
+	cfg := Config{
+		ServiceName: "test-svc",
+		LogLevel:    "info",
+		SeqURL:      "http://seq.example.com:5341",
+		DevMode:     false,
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for non-https SeqURL in non-dev mode")
+	}
+	if !strings.Contains(err.Error(), "SeqURL") {
+		t.Fatalf("expected error about SeqURL, got: %v", err)
+	}
+}
+
+func TestValidate_seqURLHTTPAllowedInDevMode(t *testing.T) {
+	cfg := Config{
+		ServiceName: "test-svc",
+		LogLevel:    "info",
+		SeqURL:      "http://localhost:5341",
+		DevMode:     true,
+		Environment: "development",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected no error for http SeqURL in dev mode, got: %v", err)
+	}
+}
+
+func TestValidate_seqURLHTTPSAlwaysValid(t *testing.T) {
+	cfg := Config{
+		ServiceName: "test-svc",
+		LogLevel:    "info",
+		SeqURL:      "https://seq.example.com:5341",
+		DevMode:     false,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected no error for https SeqURL, got: %v", err)
+	}
+}
+
+func TestValidate_devModeProductionError(t *testing.T) {
+	cfg := Config{
+		ServiceName: "test-svc",
+		LogLevel:    "info",
+		DevMode:     true,
+		Environment: "production",
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for DevMode=true in production environment")
+	}
+	if !strings.Contains(err.Error(), "DevMode") {
+		t.Fatalf("expected error about DevMode, got: %v", err)
+	}
+}
+
+func TestValidate_devModeProductionCaseInsensitive(t *testing.T) {
+	for _, env := range []string{"Production", "PRODUCTION", "production"} {
+		cfg := Config{
+			ServiceName: "test-svc",
+			LogLevel:    "info",
+			DevMode:     true,
+			Environment: env,
+		}
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatalf("expected error for DevMode=true with Environment=%q", env)
+		}
+	}
+}
+
+func TestValidate_devModeDevelopmentOK(t *testing.T) {
+	cfg := Config{
+		ServiceName: "test-svc",
+		LogLevel:    "info",
+		DevMode:     true,
+		Environment: "development",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected no error for DevMode=true in development, got: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/bravyr/bravyr-obs
 
 go 1.26.0
+
+require (
+	github.com/mattn/go-colorable v0.1.14 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/rs/zerolog v1.35.0 // indirect
+	golang.org/x/sys v0.29.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/rs/zerolog v1.35.0 h1:VD0ykx7HMiMJytqINBsKcbLS+BJ4WYjz+05us+LRTdI=
+github.com/rs/zerolog v1.35.0/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
+golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/log/log.go
+++ b/log/log.go
@@ -1,2 +1,148 @@
 // Package log provides a zerolog-based structured logger with Seq CLEF shipping.
 package log
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+// Config holds logger construction options. It mirrors the subset of
+// config.Config that is relevant to logging so the log package remains
+// importable on its own without pulling in the root config.
+type Config struct {
+	// Level is one of "debug", "info", "warn", "error", "fatal".
+	// Empty string defaults to "info".
+	Level string
+
+	// SeqURL is the base URL of the Seq server (e.g. "https://seq.example.com:5341").
+	// Leave empty to disable Seq shipping.
+	SeqURL string
+
+	// SeqAPIKey is the optional Seq ingest API key.
+	SeqAPIKey string
+
+	// ServiceName is attached as the "service" field on every log event.
+	ServiceName string
+
+	// DevMode enables human-readable console output. Must not be true in production.
+	DevMode bool
+}
+
+// Logger wraps zerolog.Logger with a lifecycle method for shutting down the
+// async Seq writer. All level methods return *zerolog.Event so callers can
+// chain fields in the standard zerolog style:
+//
+//	logger.Info().Str("key", "value").Msg("something happened")
+type Logger struct {
+	zl  zerolog.Logger
+	seq *seqWriter // nil when Seq shipping is disabled
+}
+
+// New constructs a Logger from cfg. Returns an error if the level string is
+// unrecognised (valid values: debug, info, warn, error, fatal; empty → info).
+func New(cfg Config) (*Logger, error) {
+	level, err := parseLevel(cfg.Level)
+	if err != nil {
+		return nil, err
+	}
+
+	var writers []io.Writer
+
+	if cfg.DevMode {
+		// Pretty console writer for local development. Zerolog's ConsoleWriter
+		// formats each event as colourised, human-readable text.
+		writers = append(writers, zerolog.ConsoleWriter{Out: os.Stdout})
+	} else {
+		// In non-dev mode, emit structured JSON to stderr so container runtimes
+		// and systemd can still capture logs even if Seq is misconfigured.
+		writers = append(writers, os.Stderr)
+	}
+
+	var sw *seqWriter
+	if cfg.SeqURL != "" {
+		sw = newSeqWriter(cfg.SeqURL, cfg.SeqAPIKey)
+		writers = append(writers, sw)
+	}
+
+	var w io.Writer
+	switch len(writers) {
+	case 0:
+		w = io.Discard
+	case 1:
+		w = writers[0]
+	default:
+		w = zerolog.MultiLevelWriter(writers...)
+	}
+
+	zl := zerolog.New(w).
+		Level(level).
+		With().
+		Str("service", cfg.ServiceName).
+		Timestamp().
+		Logger()
+
+	return &Logger{zl: zl, seq: sw}, nil
+}
+
+// Debug returns a *zerolog.Event for a debug-level message.
+func (l *Logger) Debug() *zerolog.Event { return l.zl.Debug() }
+
+// Info returns a *zerolog.Event for an info-level message.
+func (l *Logger) Info() *zerolog.Event { return l.zl.Info() }
+
+// Warn returns a *zerolog.Event for a warning-level message.
+func (l *Logger) Warn() *zerolog.Event { return l.zl.Warn() }
+
+// Error returns a *zerolog.Event for an error-level message.
+func (l *Logger) Error() *zerolog.Event { return l.zl.Error() }
+
+// Fatal returns a *zerolog.Event for a fatal-level message. Calling Msg() on
+// this event will call os.Exit(1) after logging — use with caution.
+func (l *Logger) Fatal() *zerolog.Event { return l.zl.Fatal() }
+
+// With returns a zerolog.Context so callers can build a sub-logger with
+// additional fixed fields. Note that the resulting sub-logger is a raw
+// zerolog.Logger (not *Logger), so it does not carry Shutdown or typed
+// level methods. This is intentional — sub-loggers share the parent's
+// writers and are flushed when the parent is shut down.
+//
+//	reqLog := logger.With().Str("request_id", id).Logger()
+func (l *Logger) With() zerolog.Context { return l.zl.With() }
+
+// Shutdown flushes the Seq writer if one is configured and waits for the
+// background goroutine to finish. ctx is accepted for API symmetry but the
+// underlying close is unconditional — Seq drain is always attempted.
+func (l *Logger) Shutdown(_ context.Context) error {
+	if l.seq != nil {
+		return l.seq.Close()
+	}
+	return nil
+}
+
+// parseLevel converts the human-readable level string to a zerolog.Level.
+// An empty string is treated as info (a sensible production default).
+func parseLevel(s string) (zerolog.Level, error) {
+	if s == "" {
+		return zerolog.InfoLevel, nil
+	}
+
+	switch strings.ToLower(s) {
+	case "debug":
+		return zerolog.DebugLevel, nil
+	case "info":
+		return zerolog.InfoLevel, nil
+	case "warn":
+		return zerolog.WarnLevel, nil
+	case "error":
+		return zerolog.ErrorLevel, nil
+	case "fatal":
+		return zerolog.FatalLevel, nil
+	default:
+		return zerolog.Disabled, fmt.Errorf("log: unrecognised level %q", s)
+	}
+}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,129 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// newTestLogger builds a Logger that writes JSON to buf, making assertions
+// on structured output straightforward without relying on console formatting.
+func newTestLogger(t *testing.T, buf *bytes.Buffer, cfg Config) *Logger {
+	t.Helper()
+
+	level, err := parseLevel(cfg.Level)
+	if err != nil {
+		t.Fatalf("parseLevel: %v", err)
+	}
+
+	zl := zerolog.New(buf).Level(level).With().
+		Str("service", cfg.ServiceName).
+		Timestamp().
+		Logger()
+
+	return &Logger{zl: zl, seq: nil}
+}
+
+func TestNew_devMode(t *testing.T) {
+	// DevMode=true should produce a logger without error.
+	l, err := New(Config{
+		ServiceName: "test-svc",
+		Level:       "info",
+		DevMode:     true,
+	})
+	if err != nil {
+		t.Fatalf("New() with DevMode=true returned error: %v", err)
+	}
+	if l == nil {
+		t.Fatal("expected non-nil Logger")
+	}
+	_ = l.Shutdown(context.Background())
+}
+
+func TestNew_invalidLevel(t *testing.T) {
+	_, err := New(Config{
+		ServiceName: "test-svc",
+		Level:       "banana",
+	})
+	if err == nil {
+		t.Fatal("expected error for unrecognised level")
+	}
+	if !strings.Contains(err.Error(), "banana") {
+		t.Fatalf("error should mention the bad level, got: %v", err)
+	}
+}
+
+func TestNew_defaultLevel(t *testing.T) {
+	// Empty Level should default to info without error.
+	l, err := New(Config{ServiceName: "test-svc", Level: ""})
+	if err != nil {
+		t.Fatalf("New() with empty Level returned error: %v", err)
+	}
+	if l == nil {
+		t.Fatal("expected non-nil Logger")
+	}
+	_ = l.Shutdown(context.Background())
+}
+
+func TestLogger_levels(t *testing.T) {
+	cases := []struct {
+		name     string
+		emit     func(l *Logger)
+		wantLevel string
+	}{
+		{"debug", func(l *Logger) { l.Debug().Msg("d") }, "debug"},
+		{"info", func(l *Logger) { l.Info().Msg("i") }, "info"},
+		{"warn", func(l *Logger) { l.Warn().Msg("w") }, "warn"},
+		{"error", func(l *Logger) { l.Error().Msg("e") }, "error"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			l := newTestLogger(t, &buf, Config{ServiceName: "svc", Level: "debug"})
+
+			tc.emit(l)
+
+			var event map[string]any
+			if err := json.Unmarshal(buf.Bytes(), &event); err != nil {
+				t.Fatalf("json.Unmarshal failed: %v (output: %q)", err, buf.String())
+			}
+			got, _ := event["level"].(string)
+			if got != tc.wantLevel {
+				t.Fatalf("expected level %q, got %q", tc.wantLevel, got)
+			}
+		})
+	}
+}
+
+func TestLogger_with(t *testing.T) {
+	var buf bytes.Buffer
+	base := newTestLogger(t, &buf, Config{ServiceName: "svc", Level: "info"})
+
+	sub := base.With().Str("request_id", "abc-123").Logger()
+	sub.Info().Msg("scoped")
+
+	var event map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &event); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	rid, _ := event["request_id"].(string)
+	if rid != "abc-123" {
+		t.Fatalf("expected request_id=abc-123, got %q", rid)
+	}
+}
+
+func TestShutdown_noSeq(t *testing.T) {
+	l, err := New(Config{ServiceName: "test-svc", Level: "info"})
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+	// Must not panic or error when no Seq writer is configured.
+	if err := l.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() returned unexpected error: %v", err)
+	}
+}

--- a/log/seq.go
+++ b/log/seq.go
@@ -1,0 +1,181 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	seqBufCap       = 1024
+	seqBatchSize    = 100
+	seqFlushTimeout = 500 * time.Millisecond
+	seqHTTPTimeout  = 10 * time.Second
+)
+
+// seqWriter is an async, batching zerolog writer that ships CLEF-formatted
+// JSON events to a Seq server via HTTP POST. It is safe for concurrent use.
+//
+// CLEF (Compact Log Event Format) is Seq's native ingestion format. The only
+// difference from zerolog's output is the field names for the three reserved
+// fields: @t (time), @l (level), @mt (message template).
+type seqWriter struct {
+	url    string
+	apiKey string
+	client *http.Client
+	buf    chan []byte
+	wg     sync.WaitGroup
+
+	closeOnce sync.Once
+
+	// dropped counts events silently discarded when the channel was full.
+	dropped atomic.Int64
+
+	// sendFailed counts events lost due to delivery failures.
+	sendFailed atomic.Int64
+}
+
+// newSeqWriter creates a seqWriter and starts its background flush goroutine.
+// The caller must call Close() to drain and shut down.
+func newSeqWriter(url, apiKey string) *seqWriter {
+	w := &seqWriter{
+		url:    url,
+		apiKey: apiKey,
+		buf:    make(chan []byte, seqBufCap),
+		client: &http.Client{
+			Timeout: seqHTTPTimeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					MinVersion: tls.VersionTLS12,
+				},
+			},
+		},
+	}
+
+	w.wg.Add(1)
+	go w.run()
+
+	return w
+}
+
+// Write implements io.Writer. It rewrites the three reserved zerolog field
+// names to their CLEF equivalents, copies the payload (zerolog reuses the
+// underlying buffer), and enqueues it for async delivery. If the channel is
+// full the event is dropped and the dropped counter is incremented.
+func (w *seqWriter) Write(p []byte) (int, error) {
+	// Rewrite field names: "time" → "@t", "level" → "@l", "message" → "@mt".
+	// bytes.Replace with n=1 targets only the first occurrence. This is safe
+	// because zerolog emits its built-in fields first (level, then time via
+	// Timestamp), user fields in the middle, and message last (written by Msg).
+	// The n=1 replacement therefore always hits the zerolog-emitted key.
+	out := bytes.Replace(p, []byte(`"time"`), []byte(`"@t"`), 1)
+	out = bytes.Replace(out, []byte(`"level"`), []byte(`"@l"`), 1)
+	out = bytes.Replace(out, []byte(`"message"`), []byte(`"@mt"`), 1)
+
+	// Copy because zerolog reuses the buffer backing p after Write returns.
+	copied := make([]byte, len(out))
+	copy(copied, out)
+
+	select {
+	case w.buf <- copied:
+	default:
+		w.dropped.Add(1)
+	}
+
+	return len(p), nil
+}
+
+// Close signals the background goroutine to drain and stop. It blocks until
+// all buffered events have been flushed. Safe to call multiple times.
+func (w *seqWriter) Close() error {
+	w.closeOnce.Do(func() {
+		close(w.buf)
+	})
+	w.wg.Wait()
+	return nil
+}
+
+// run is the background goroutine that batches and ships events to Seq.
+func (w *seqWriter) run() {
+	defer w.wg.Done()
+
+	batch := make([][]byte, 0, seqBatchSize)
+	ticker := time.NewTicker(seqFlushTimeout)
+	defer ticker.Stop()
+
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		// Single-attempt POST; failed batches are retried on the next tick.
+		if err := w.send(batch); err != nil {
+			w.sendFailed.Add(int64(len(batch)))
+			fmt.Fprintf(os.Stderr, "seq: batch delivery failed (%d events): %v\n", len(batch), err)
+		}
+		batch = batch[:0]
+	}
+
+	for {
+		select {
+		case event, ok := <-w.buf:
+			if !ok {
+				// Channel closed — drain remaining events and exit.
+				flush()
+				return
+			}
+			batch = append(batch, event)
+			if len(batch) >= seqBatchSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		}
+	}
+}
+
+// send POSTs a CLEF batch to Seq. Returns nil on success. Failed batches are
+// retried implicitly on the next ticker flush cycle.
+func (w *seqWriter) send(batch [][]byte) error {
+	body := bytes.Join(batch, []byte("\n"))
+	return w.post(body)
+}
+
+// post performs a single HTTP POST to the Seq ingestion endpoint.
+func (w *seqWriter) post(body []byte) error {
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		w.url+"/api/events/raw",
+		bytes.NewReader(body),
+	)
+	if err != nil {
+		return fmt.Errorf("seq: building request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/vnd.serilog.clef")
+	if w.apiKey != "" {
+		req.Header.Set("X-Seq-ApiKey", w.apiKey)
+	}
+
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("seq: http request: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("seq: server returned %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/log/seq_test.go
+++ b/log/seq_test.go
@@ -1,0 +1,262 @@
+package log
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSeqWriter_CLEFRewrite(t *testing.T) {
+	w := &seqWriter{
+		buf: make(chan []byte, 16),
+	}
+
+	input := []byte(`{"level":"info","time":"2026-04-06T00:00:00Z","message":"hello"}`)
+	n, err := w.Write(input)
+	if err != nil {
+		t.Fatalf("Write() returned error: %v", err)
+	}
+	if n != len(input) {
+		t.Fatalf("Write() returned n=%d, want %d", n, len(input))
+	}
+
+	got := <-w.buf
+
+	var event map[string]any
+	if err := json.Unmarshal(got, &event); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v (output: %q)", err, got)
+	}
+
+	if _, ok := event["@t"]; !ok {
+		t.Errorf("expected @t field, got keys: %v", event)
+	}
+	if _, ok := event["@l"]; !ok {
+		t.Errorf("expected @l field, got keys: %v", event)
+	}
+	if _, ok := event["@mt"]; !ok {
+		t.Errorf("expected @mt field, got keys: %v", event)
+	}
+	if _, ok := event["level"]; ok {
+		t.Error("original 'level' key must be removed")
+	}
+	if _, ok := event["time"]; ok {
+		t.Error("original 'time' key must be removed")
+	}
+	if _, ok := event["message"]; ok {
+		t.Error("original 'message' key must be removed")
+	}
+}
+
+func TestSeqWriter_dropOnFull(t *testing.T) {
+	w := &seqWriter{
+		buf: make(chan []byte, 2),
+	}
+
+	for i := range 2 {
+		if _, err := w.Write([]byte(`{"level":"info","time":"t","message":"` + string(rune('a'+i)) + `"}`)); err != nil {
+			t.Fatalf("Write() error: %v", err)
+		}
+	}
+
+	if _, err := w.Write([]byte(`{"level":"info","time":"t","message":"overflow"}`)); err != nil {
+		t.Fatalf("Write() error on drop: %v", err)
+	}
+
+	if got := w.dropped.Load(); got != 1 {
+		t.Fatalf("expected dropped=1, got %d", got)
+	}
+}
+
+func TestSeqWriter_batchFlush(t *testing.T) {
+	var mu sync.Mutex
+	var received [][]byte
+	var reqCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqCount.Add(1)
+		if ct := r.Header.Get("Content-Type"); ct != "application/vnd.serilog.clef" {
+			t.Errorf("expected CLEF content-type, got %q", ct)
+		}
+		if key := r.Header.Get("X-Seq-ApiKey"); key != "test-key" {
+			t.Errorf("expected X-Seq-ApiKey=test-key, got %q", key)
+		}
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r.Body)
+		mu.Lock()
+		received = append(received, buf.Bytes())
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sw := newSeqWriter(srv.URL, "test-key")
+
+	const n = 5
+	for i := range n {
+		line := []byte(`{"level":"info","time":"t","message":"` + string(rune('a'+i)) + `"}`)
+		if _, err := sw.Write(line); err != nil {
+			t.Fatalf("Write() error: %v", err)
+		}
+	}
+
+	if err := sw.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+
+	if reqCount.Load() == 0 {
+		t.Fatal("expected at least one POST to Seq server")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	total := 0
+	for _, body := range received {
+		scanner := bufio.NewScanner(bytes.NewReader(body))
+		for scanner.Scan() {
+			if line := scanner.Bytes(); len(line) > 0 {
+				total++
+			}
+		}
+	}
+	if total != n {
+		t.Fatalf("expected %d events delivered, got %d", n, total)
+	}
+}
+
+func TestSeqWriter_sendError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	sw := &seqWriter{
+		url:    srv.URL,
+		apiKey: "",
+		buf:    make(chan []byte, 16),
+		client: srv.Client(),
+	}
+
+	batch := [][]byte{[]byte(`{"@t":"t","@l":"info","@mt":"error test"}`)}
+	err := sw.send(batch)
+	if err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+}
+
+func TestSeqWriter_dropOn4xx(t *testing.T) {
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	sw := &seqWriter{
+		url:    srv.URL,
+		apiKey: "",
+		buf:    make(chan []byte, 16),
+		client: srv.Client(),
+	}
+
+	batch := [][]byte{[]byte(`{"@t":"t","@l":"info","@mt":"drop test"}`)}
+	err := sw.send(batch)
+	if err == nil {
+		t.Fatal("expected error for 400 response, got nil")
+	}
+	if got := callCount.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 HTTP call (no retry on 4xx), got %d", got)
+	}
+}
+
+func TestSeqWriter_close(t *testing.T) {
+	var delivered atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scanner := bufio.NewScanner(r.Body)
+		for scanner.Scan() {
+			if len(scanner.Bytes()) > 0 {
+				delivered.Add(1)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	sw := newSeqWriter(srv.URL, "")
+
+	for range 10 {
+		_, _ = sw.Write([]byte(`{"level":"info","time":"t","message":"drain test"}`))
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- sw.Close() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Close() returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close() did not return within 5s")
+	}
+
+	if n := delivered.Load(); n != 10 {
+		t.Fatalf("expected 10 events delivered after close, got %d", n)
+	}
+}
+
+func TestSeqWriter_doubleClose(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // makes the port refuse connections
+	sw := newSeqWriter(srv.URL, "")
+	if err := sw.Close(); err != nil {
+		t.Fatalf("first Close() error: %v", err)
+	}
+	// Second close must not panic.
+	if err := sw.Close(); err != nil {
+		t.Fatalf("second Close() error: %v", err)
+	}
+}
+
+func TestNew_withSeqURL(t *testing.T) {
+	var delivered atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scanner := bufio.NewScanner(r.Body)
+		for scanner.Scan() {
+			if len(scanner.Bytes()) > 0 {
+				delivered.Add(1)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	l, err := New(Config{
+		ServiceName: "test-svc",
+		Level:       "info",
+		SeqURL:      srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	l.Info().Msg("integration test")
+
+	if err := l.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error: %v", err)
+	}
+
+	if n := delivered.Load(); n != 1 {
+		t.Fatalf("expected 1 event delivered via Seq, got %d", n)
+	}
+}

--- a/obs.go
+++ b/obs.go
@@ -5,10 +5,12 @@ package obs
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/bravyr/bravyr-obs/config"
 	"github.com/bravyr/bravyr-obs/health"
+	obslog "github.com/bravyr/bravyr-obs/log"
 )
 
 // Config is the top-level configuration for the observability stack.
@@ -17,7 +19,8 @@ type Config = config.Config
 // Obs holds the initialized observability providers and exposes
 // middleware and health check handlers as methods.
 type Obs struct {
-	cfg Config
+	cfg    Config
+	logger *obslog.Logger
 }
 
 // Init initializes logging, tracing, and metrics based on the provided
@@ -27,12 +30,29 @@ func Init(cfg Config) (*Obs, error) {
 		return nil, err
 	}
 
-	return &Obs{cfg: cfg}, nil
+	logger, err := obslog.New(obslog.Config{
+		Level:       cfg.LogLevel,
+		SeqURL:      cfg.SeqURL,
+		SeqAPIKey:   cfg.SeqAPIKey,
+		ServiceName: cfg.ServiceName,
+		DevMode:     cfg.DevMode,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("log init: %w", err)
+	}
+
+	return &Obs{cfg: cfg, logger: logger}, nil
 }
+
+// Logger returns the structured logger. It is safe to use from multiple
+// goroutines. The returned pointer is valid until Shutdown is called.
+func (o *Obs) Logger() *obslog.Logger { return o.logger }
 
 // Shutdown flushes all telemetry pipelines and releases resources.
 func (o *Obs) Shutdown(ctx context.Context) {
-	// Phases 1-2: flush log, trace, and metrics pipelines.
+	if o.logger != nil {
+		_ = o.logger.Shutdown(ctx)
+	}
 }
 
 // Middleware returns an http.Handler middleware that adds request logging,

--- a/obs_test.go
+++ b/obs_test.go
@@ -57,6 +57,38 @@ func TestMiddleware_passthrough(t *testing.T) {
 	}
 }
 
+func TestInit_createsLogger(t *testing.T) {
+	o, err := Init(Config{ServiceName: "test-svc", LogLevel: "info"})
+	if err != nil {
+		t.Fatalf("Init() returned error: %v", err)
+	}
+	if o.Logger() == nil {
+		t.Fatal("Logger() returned nil after Init")
+	}
+	o.Shutdown(context.Background())
+}
+
+func TestShutdown_flushesLogger(t *testing.T) {
+	o, err := Init(Config{ServiceName: "test-svc", LogLevel: "info"})
+	if err != nil {
+		t.Fatalf("Init() returned error: %v", err)
+	}
+	// Shutdown must complete without panicking or blocking.
+	o.Shutdown(context.Background())
+}
+
+func TestInit_allValidLevels(t *testing.T) {
+	for _, level := range []string{"debug", "info", "warn", "error", "fatal"} {
+		t.Run(level, func(t *testing.T) {
+			o, err := Init(Config{ServiceName: "test-svc", LogLevel: level})
+			if err != nil {
+				t.Fatalf("Init(%q) returned error: %v", level, err)
+			}
+			o.Shutdown(context.Background())
+		})
+	}
+}
+
 func TestHealthHandler_noChecks(t *testing.T) {
 	o, err := Init(Config{ServiceName: "test-svc", LogLevel: "info"})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Implement `log` package with zerolog-backed Logger and async Seq CLEF HTTP sink
- `seqWriter`: buffered channel (1024 cap), single background goroutine, CLEF field rewriting, batch flush (100 events or 500ms)
- Config validations: SeqURL must be HTTPS in non-dev mode, DevMode forbidden in production (case-insensitive)
- Wire logger into `obs.Init()`, expose via `obs.Logger()`, flush on `obs.Shutdown()`
- Non-dev mode defaults to stderr JSON output (no silent discard)
- `sync.Once` on Close() prevents double-close panic
- Send failures tracked via `sendFailed` counter with stderr output
- Aligned valid log levels between config.Validate() and log.parseLevel()

## Test plan

- [x] `go test ./... -count=1` passes (all packages green)
- [x] `make lint` passes with 0 issues
- [x] Logger: New with DevMode, invalid level, default level, all level methods, With() sub-logger, Shutdown
- [x] seqWriter: CLEF rewrite, drop on full, batch flush with httptest, send error, 4xx drop, close drain, double-close, New+SeqURL integration
- [x] Config: SeqURL HTTPS enforcement, DevMode+production case-insensitive, level alignment
- [x] obs: Init creates logger, all valid levels, Shutdown flushes
- [ ] CI workflow runs green

Closes #2