### PR TITLE
feat: add OTLPInsecure config for plaintext gRPC to internal collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `redistrace` sub-package for Redis command span instrumentation via redisotel (`db.statement` off by default)
 - `temporaltrace` sub-package for Temporal workflow/activity span instrumentation via the Temporal OTel contrib interceptor
+- `OTLPInsecure` config field (`OBS_OTLP_INSECURE`) for plaintext gRPC to internal collectors without enabling DevMode
 - Coolify deployment guide (`docs/coolify-deployment.md`)
 - `pgxtrace` sub-package for automatic pgx database query span instrumentation via otelpgx
 - `CachedCheck()` wrapper that caches healthy results for a configurable TTL to prevent health check amplification

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ All configuration fields can be set via struct literal or environment variables:
 | `OTLPEndpoint` | `OBS_OTLP_ENDPOINT` | | OpenTelemetry Collector gRPC endpoint |
 | `SampleRate` | `OBS_SAMPLE_RATE` | `1.0` | Fraction of traces to sample (0.0–1.0); overridden to 1.0 when `DevMode` is true |
 | `DevMode` | `OBS_DEV_MODE` | `false` | Enable pretty console logging and always-sample tracing |
+| `OTLPInsecure` | `OBS_OTLP_INSECURE` | `false` | Use plaintext gRPC to OTLP collector (for internal collectors on private networks) |
 | `MetricsPrefix` | `OBS_METRICS_PREFIX` | | Prefix prepended to all metric names (e.g. `"myapi"` → `"myapi_http_requests_total"`); empty means no prefix |
 
 ## Architecture

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	OTLPEndpoint  string  `env:"OBS_OTLP_ENDPOINT"`
 	SampleRate    float64 `env:"OBS_SAMPLE_RATE"    envDefault:"1.0"`
 	DevMode       bool    `env:"OBS_DEV_MODE"       envDefault:"false"`
+	OTLPInsecure  bool    `env:"OBS_OTLP_INSECURE"  envDefault:"false"`
 	MetricsPrefix string  `env:"OBS_METRICS_PREFIX" envDefault:""`
 }
 
@@ -58,8 +59,8 @@ func (c Config) Validate() error {
 // String returns a human-readable representation of the configuration.
 func (c Config) String() string {
 	return fmt.Sprintf(
-		"Config{ServiceName:%q Environment:%q LogLevel:%q OTLPEndpoint:%q SampleRate:%g DevMode:%t MetricsPrefix:%q}",
-		c.ServiceName, c.Environment, c.LogLevel, c.OTLPEndpoint, c.SampleRate, c.DevMode, c.MetricsPrefix,
+		"Config{ServiceName:%q Environment:%q LogLevel:%q OTLPEndpoint:%q SampleRate:%g DevMode:%t OTLPInsecure:%t MetricsPrefix:%q}",
+		c.ServiceName, c.Environment, c.LogLevel, c.OTLPEndpoint, c.SampleRate, c.DevMode, c.OTLPInsecure, c.MetricsPrefix,
 	)
 }
 
@@ -100,6 +101,7 @@ func (c Config) MarshalJSON() ([]byte, error) {
 		OTLPEndpoint  string  `json:"otlp_endpoint"`
 		SampleRate    float64 `json:"sample_rate"`
 		DevMode       bool    `json:"dev_mode"`
+		OTLPInsecure  bool    `json:"otlp_insecure"`
 		MetricsPrefix string  `json:"metrics_prefix"`
 	}{
 		ServiceName:   c.ServiceName,
@@ -108,6 +110,7 @@ func (c Config) MarshalJSON() ([]byte, error) {
 		OTLPEndpoint:  c.OTLPEndpoint,
 		SampleRate:    c.SampleRate,
 		DevMode:       c.DevMode,
+		OTLPInsecure:  c.OTLPInsecure,
 		MetricsPrefix: c.MetricsPrefix,
 	})
 }

--- a/obs.go
+++ b/obs.go
@@ -60,6 +60,7 @@ func Init(cfg Config) (*Obs, error) {
 		OTLPEndpoint: cfg.OTLPEndpoint,
 		SampleRate:   cfg.SampleRate,
 		DevMode:      cfg.DevMode,
+		OTLPInsecure: cfg.OTLPInsecure,
 	})
 	if err != nil {
 		// Logger was successfully constructed; shut it down before returning

--- a/trace/config.go
+++ b/trace/config.go
@@ -28,6 +28,11 @@ type Config struct {
 	// DevMode enables AlwaysSample and insecure (plaintext) gRPC transport.
 	// Must not be true in production.
 	DevMode bool
+
+	// OTLPInsecure enables plaintext gRPC transport to the OTLP collector
+	// without enabling DevMode. Use for internal collectors on private
+	// Docker networks where TLS adds complexity with no security benefit.
+	OTLPInsecure bool
 }
 
 // Validate returns an error if the Config is not usable by Init.

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -43,9 +43,10 @@ func Init(ctx context.Context, cfg Config) (*Provider, error) {
 	opts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(cfg.OTLPEndpoint),
 	}
-	if cfg.DevMode {
-		// Insecure transport is intentional in dev — the collector runs locally
-		// without TLS. Non-dev mode uses the default TLS configuration.
+	if cfg.DevMode || cfg.OTLPInsecure {
+		// Insecure (plaintext) transport for local/internal collectors.
+		// DevMode always enables it; OTLPInsecure enables it independently
+		// for production services connecting to internal collectors.
 		opts = append(opts, otlptracegrpc.WithInsecure())
 	}
 


### PR DESCRIPTION
## Problem

DevMode controls both log format (pretty vs JSON) AND gRPC transport (insecure vs TLS). Production services with internal OTel collectors need plaintext gRPC but must keep JSON logs and production sampling.

## Solution

Add `OTLPInsecure bool` (`OBS_OTLP_INSECURE` env var) that enables plaintext gRPC independently of DevMode.

## Usage

```
OBS_OTLP_INSECURE=true
OBS_OTLP_ENDPOINT=otel-collector:4317
OBS_DEV_MODE=false
```

Logs stay JSON, sampling stays production-grade, gRPC uses plaintext.

## Test plan

- [x] `make check` passes (all 10 packages)
- [ ] API connects to collector without TLS error