### PR TITLE
feat(stack): add Prometheus bearer token auth for /metrics scraping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `redistrace` sub-package for Redis command span instrumentation via redisotel (`db.statement` off by default)
 - `temporaltrace` sub-package for Temporal workflow/activity span instrumentation via the Temporal OTel contrib interceptor
+- Prometheus bearer token auth for `/metrics` scraping via `INTERNAL_API_KEY` env var
 - `OTLPInsecure` config field (`OBS_OTLP_INSECURE`) for plaintext gRPC to internal collectors without enabling DevMode
 - Coolify deployment guide (`docs/coolify-deployment.md`)
 - `pgxtrace` sub-package for automatic pgx database query span instrumentation via otelpgx

--- a/stack/.env.example
+++ b/stack/.env.example
@@ -4,3 +4,7 @@
 # Grafana admin credentials. Stack will fail to start if these are not set.
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=CHANGEME
+
+# Internal API key for Prometheus to scrape /metrics endpoints.
+# Must match INTERNAL_API_KEY set in the socialup-api Coolify env vars.
+INTERNAL_API_KEY=CHANGEME

--- a/stack/docker-compose.yaml
+++ b/stack/docker-compose.yaml
@@ -69,13 +69,19 @@ services:
     image: prom/prometheus:v3.11.0
     container_name: bravyr_prometheus
     restart: unless-stopped
+    entrypoint: ["/bin/sh", "-c"]
     command:
-      - "--config.file=/etc/prometheus/prometheus.yml"
-      - "--storage.tsdb.path=/prometheus"
-      - "--storage.tsdb.retention.time=30d"
-      - "--web.enable-lifecycle"
-      - "--web.enable-remote-write-receiver"
-      - "--enable-feature=exemplar-storage"
+      - |
+        echo "$INTERNAL_API_KEY" > /etc/prometheus/api_token
+        exec prometheus \
+          --config.file=/etc/prometheus/prometheus.yml \
+          --storage.tsdb.path=/prometheus \
+          --storage.tsdb.retention.time=30d \
+          --web.enable-lifecycle \
+          --web.enable-remote-write-receiver \
+          --enable-feature=exemplar-storage
+    environment:
+      INTERNAL_API_KEY: "${INTERNAL_API_KEY:?INTERNAL_API_KEY must be set in .env}"
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus

--- a/stack/prometheus/prometheus.yml
+++ b/stack/prometheus/prometheus.yml
@@ -51,6 +51,7 @@ scrape_configs:
   # ---------------------------------------------------------------------------
   - job_name: "socialup-api"
     metrics_path: "/metrics"
+    bearer_token_file: /etc/prometheus/api_token
     static_configs:
       - targets:
           - "api:8080"


### PR DESCRIPTION
## Summary

The socialup-api `/metrics` endpoint is now protected by `internalKeyAuth` middleware. Prometheus needs to send `Authorization: Bearer <key>` when scraping.

### How it works

1. `INTERNAL_API_KEY` env var is set in Coolify (same value as the API's key)
2. Prometheus entrypoint writes it to `/etc/prometheus/api_token` at startup
3. `bearer_token_file` in the scrape config reads from that file
4. Every scrape request includes `Authorization: Bearer <key>`

### Files changed

- `prometheus.yml` — added `bearer_token_file` to socialup-api job
- `docker-compose.yaml` — prometheus entrypoint writes env var to token file
- `.env.example` — added `INTERNAL_API_KEY`

## Setup

In Coolify, add to the monitoring stack env vars:
```
INTERNAL_API_KEY=<same key as socialup-api>
```

Closes #41