### PR TITLE
feat(stack): Grafana Faro ingest for frontend observability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,21 @@ jobs:
           govulncheck ./...
 
       - run: go mod verify
+
+  alloy-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Grafana Alloy
+        run: |
+          curl -sSL -o alloy.zip \
+            https://github.com/grafana/alloy/releases/download/v1.14.0/alloy-linux-amd64.zip
+          unzip -q alloy.zip
+          chmod +x alloy-linux-amd64
+          sudo mv alloy-linux-amd64 /usr/local/bin/alloy
+
+      - name: Verify Alloy config parses
+        env:
+          FARO_ALLOWED_ORIGINS: "https://example.com"
+        run: alloy fmt --test stack/alloy/config.alloy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Grafana dashboard `Frontend RUM (Faro)` covering page loads, distinct sessions, JS exceptions, Core Web Vitals (LCP/INP/CLS p75 by route), browser/OS/route breakdowns, and an exception table with Tempo trace links
 - Defence-in-depth credential scrubbing in the Alloy Faro Loki pipeline (`Bearer …`, `sk-…`, `eyJ…` prefixes redacted); `user_id`, `session_id`, `trace_id`, `release`, `browser`, `os`, `route` attached as Loki structured metadata to avoid index cardinality blow-ups
 - Frontend observability plan (`docs/plans/009-frontend-observability.md`)
+- Host bind-mount + Grafana 504 diagnostics plan (`docs/plans/010-host-bind-mounts.md`) — next iteration after this PR
 - Integration guide addendum documenting the Faro SDK env var contract for the `socialup` React app
 - `stack/scripts/smoke-faro.sh` — end-to-end smoke test that posts a synthetic Faro payload to the local Alloy receiver and asserts the span surfaces in Tempo and the log surfaces in Loki
 - `alloy-fmt` CI job that runs `alloy fmt --test` against `stack/alloy/config.alloy` on every PR, catching syntax regressions before merge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Frontend observability ingest (`faro.receiver` in Alloy) for Grafana Faro Web SDK clients; traces fan out to the existing OTel Collector, logs and measurements land in a dedicated Loki pipeline under `{source="faro"}`
+- Coolify/Traefik container labels on Alloy for the public ingest endpoint at `https://obs.bravyr.com/collect` with basic-auth, CORS allowlist, 20 r/s rate limit, 1 MB body cap, and HSTS
+- Grafana dashboard `Frontend RUM (Faro)` covering page loads, distinct sessions, JS exceptions, Core Web Vitals (LCP/INP/CLS p75 by route), browser/OS/route breakdowns, and an exception table with Tempo trace links
+- Defence-in-depth credential scrubbing in the Alloy Faro Loki pipeline (`Bearer …`, `sk-…`, `eyJ…` prefixes redacted); `user_id`, `session_id`, `trace_id`, `release`, `browser`, `os`, `route` attached as Loki structured metadata to avoid index cardinality blow-ups
+- Frontend observability plan (`docs/plans/009-frontend-observability.md`)
+- Integration guide addendum documenting the Faro SDK env var contract for the `socialup` React app
+- `stack/scripts/smoke-faro.sh` — end-to-end smoke test that posts a synthetic Faro payload to the local Alloy receiver and asserts the span surfaces in Tempo and the log surfaces in Loki
+- `alloy-fmt` CI job that runs `alloy fmt --test` against `stack/alloy/config.alloy` on every PR, catching syntax regressions before merge
+- Alloy container healthcheck on `/-/ready` (port 12345) so orchestrators surface crashes instead of silently continuing
 - `redistrace` sub-package for Redis command span instrumentation via redisotel (`db.statement` off by default)
 - `temporaltrace` sub-package for Temporal workflow/activity span instrumentation via the Temporal OTel contrib interceptor
 - Prometheus bearer token auth for `/metrics` scraping via `INTERNAL_API_KEY` env var
@@ -29,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Tempo `block_retention` raised from 72h to 14 days and `max_block_bytes` from 1 MB to 100 MB to absorb frontend trace volume without tiny-block accumulation
+- Loki `retention_period` raised from 72h to 14 days; `ingestion_rate_mb` raised from 8 to 32 (burst 64) to accommodate Faro payloads; `allow_structured_metadata: true` added
+- `stack/docker-compose.yaml` — Alloy service now depends on `otel-collector` (Faro traces fan out through it), requires `FARO_ALLOWED_ORIGINS` env var, and carries Traefik middleware labels for the public `/collect` route
+- `stack/.env.example` — added `FARO_PUBLIC_HOST`, `FARO_ALLOWED_ORIGINS`, `FARO_APP_KEY`, `FARO_BASIC_AUTH_HTPASSWD`
 - Non-dev log output now writes to stdout (was stderr); this aligns with the 12-factor app convention and allows Promtail to collect logs via the Docker socket without additional configuration
 - `stack/docker-compose.yaml` — replaced Seq service with Loki + Promtail; updated Grafana `depends_on` to require Loki instead of Seq; removed `GF_INSTALL_PLUGINS` env var (no third-party Grafana plugins needed)
 - `stack/docker-compose.dev.yaml` — removed Seq service and `seq_data_dev` volume; dev stack now contains only OTel Collector and Prometheus; dev mode uses console output to stdout, no log backend required

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # bravyr-obs
 
 Opinionated observability library for Go services. Structured logging,
-distributed tracing, and Prometheus metrics in one `Init()` call.
+distributed tracing, and Prometheus metrics in one `Init()` call. The
+companion `stack/` folder ships a self-hosted OTel Collector + Tempo +
+Loki + Prometheus + Grafana + Alloy deployment, including a Grafana
+Faro ingest path for **frontend RUM** (web-vitals, JS errors, distributed
+traces browser → Go) that correlates with backend spans out of the box.
 
-See the [Integration Guide](docs/integration-guide.md) for step-by-step setup instructions.
+See the [Integration Guide](docs/integration-guide.md) for step-by-step setup instructions, including the frontend section for Faro Web SDK clients.
 
 ## Quick Start
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -386,3 +386,102 @@ r.Use(trace.UserAttributesMiddleware(...)) // 5. adds user to span
 ```
 
 `o.Middleware()` handles steps 1-3 automatically.
+
+## Frontend Observability (Grafana Faro)
+
+The stack ingests browser telemetry (RUM) from any Grafana Faro Web SDK client through Alloy's `faro.receiver`. Traces reuse the backend's OTel Collector so a single Tempo trace spans the browser span and its downstream Go handler span.
+
+### Backend requirements
+
+No code changes are required in Go services — the existing middleware already accepts the W3C `traceparent` header propagated by Faro's fetch/XHR instrumentation. Verify the client app sends requests to the same API host (or CORS exposes `traceparent`).
+
+### Ingest endpoint
+
+Public route, terminated by Coolify/Traefik:
+
+```
+POST https://obs.bravyr.com/collect
+Authorization: Basic base64("faro:${FARO_APP_KEY}")
+Origin: https://<configured-origin>
+```
+
+Traefik enforces basic-auth, the origin allowlist, a 20 r/s rate limit (100 r/s burst), a 1 MB body cap, and HSTS. Alloy additionally enforces the CORS allowlist at the application layer.
+
+### Stack environment variables
+
+See `stack/.env.example`:
+
+| Variable | Purpose |
+|----------|---------|
+| `FARO_PUBLIC_HOST` | FQDN Traefik routes `/collect` for (default `obs.bravyr.com`). |
+| `FARO_ALLOWED_ORIGINS` | Comma-separated exact origins allowed to POST telemetry. |
+| `FARO_APP_KEY` | Shared write-only token shipped to browsers as the basic-auth password. Per-env, rotatable. |
+| `FARO_BASIC_AUTH_HTPASSWD` | Bcrypt htpasswd line for the Traefik `basicauth` middleware. Generate with `htpasswd -nbB faro "$FARO_APP_KEY"` and double every `$` to `$$` before pasting. |
+
+### Frontend SDK integration
+
+In the React (or any JS) client, pin the SDK versions and initialize before the app mounts:
+
+```ts
+import { initializeFaro, getWebInstrumentations } from "@grafana/faro-web-sdk";
+import { TracingInstrumentation } from "@grafana/faro-web-tracing";
+
+initializeFaro({
+  url: import.meta.env.VITE_FARO_URL,
+  apiKey: import.meta.env.VITE_FARO_APP_KEY,
+  app: {
+    name: import.meta.env.VITE_FARO_APP_NAME,
+    version: import.meta.env.VITE_FARO_APP_VERSION,
+    environment: import.meta.env.VITE_FARO_ENVIRONMENT,
+  },
+  sessionTracking: {
+    enabled: true,
+    samplingRate: Number(import.meta.env.VITE_FARO_SAMPLE_RATE ?? 1.0),
+  },
+  instrumentations: [
+    ...getWebInstrumentations({ captureConsole: true }),
+    new TracingInstrumentation(),
+  ],
+  beforeSend: (item) => {
+    // Strip query strings, redact auth headers, drop request/response bodies,
+    // truncate stacks at 4096 chars, swap user email for opaque user ID.
+    return scrubFaroItem(item);
+  },
+});
+```
+
+The SDK sends `Authorization: Basic base64("faro:$VITE_FARO_APP_KEY")` via its fetch transport.
+
+### Client env var contract
+
+| Variable | Example |
+|----------|---------|
+| `VITE_FARO_URL` | `https://obs.bravyr.com/collect` |
+| `VITE_FARO_APP_NAME` | `socialup-web` |
+| `VITE_FARO_APP_VERSION` | `0.12.3+abc1234` (git SHA suffix) |
+| `VITE_FARO_ENVIRONMENT` | `development` / `staging` / `production` |
+| `VITE_FARO_SAMPLE_RATE` | `1.0` non-prod, `0.1` prod |
+| `VITE_FARO_APP_KEY` | basic-auth password — per-env |
+
+### Sampling defaults
+
+| Environment | Errors | Page loads | Web-vitals |
+|-------------|--------|-----------|------------|
+| Production | 100% | 10% | 100% |
+| Staging | 100% | 100% | 100% |
+| Development | 100% | 100% | 100% |
+
+### Route labelling
+
+The Grafana dashboard aggregates Core Web Vitals and exceptions by `route`. For `route` to be useful, the SDK must emit a **normalized** path (e.g. `/user/:id`, not `/user/12345`). Call `faro.api.setView({ name: "/user/:id" })` on every navigation — typically inside your router's location-change hook. The Alloy pipeline runs a regex backstop that replaces numeric and UUID path segments, but SDK-side normalization is the source of truth.
+
+### PII and GDPR
+
+- Always implement `beforeSend`. Strip query strings, drop request/response bodies, redact `Authorization`/`Cookie`/`X-Api-Key` headers, truncate stacks.
+- Never serve `.map` files publicly. Upload source maps to a private symbolicator keyed by release ID.
+- The Alloy Loki pipeline scrubs client IP, remote-address, and `X-Forwarded-For` shaped fields from the stored log line. User-Agent is retained as structured metadata.
+- Default retention for Tempo and Loki is 14 days.
+
+### Dashboard
+
+Grafana auto-provisions **Frontend RUM (Faro)** — page loads, distinct sessions, JS exceptions, Core Web Vitals (LCP, INP, CLS) p75 by route, browser/OS/route breakdowns, and an exception table with one-click Tempo trace links.

--- a/docs/plans/009-frontend-observability.md
+++ b/docs/plans/009-frontend-observability.md
@@ -1,0 +1,358 @@
+# 009 — Frontend Observability (Grafana Faro)
+
+Add frontend RUM + distributed tracing (browser → Go backend) to the stack.
+Platform-agnostic SDK choice (Grafana Faro) keeps the path open for
+post-React frameworks without reshaping the backend. Target consumer
+repo: `../socialup` (React, bun). Target domains:
+`https://socialup-staging.bravyr.com`, `https://socialup.bravyr.com`.
+
+Ingest endpoint: `https://obs.bravyr.com/collect` (Traefik via Coolify → Alloy `faro.receiver`).
+
+---
+
+## 1. Product Owner
+
+### Goal & user value
+
+- **Founders** answer "is the app fast and stable for real users?" with per-route web-vitals percentiles and JS error rates, no second SaaS vendor.
+- **Solo developer** jumps from a browser error straight to the exact Go handler span in one Tempo trace — cuts MTTR from guesswork to minutes.
+- **Design/marketing** see which routes degrade INP/LCP after design changes, tied to release version.
+
+### In scope
+
+- Web-vitals capture: CLS, LCP, FCP, INP, TTFB per route.
+- JS errors with stack traces + source-map resolution.
+- Unhandled promise rejections.
+- Console capture at `warn` + `error`.
+- Browser→Go trace context propagation via W3C `traceparent` header (fetch + XHR instrumentation).
+- Custom events API (`faro.api.pushEvent`) for product milestones.
+- Opaque session ID + user ID tagging.
+- Release/version tagging from build-time env var.
+- Configurable sampling (default: 100% errors, 10% page loads in prod, 100% everything in staging/dev).
+- Alloy `faro.receiver` exposed via Coolify/Traefik with basic-auth + CORS allowlist.
+- New Grafana dashboard for frontend RUM.
+- Integration guide addendum.
+
+### Out of scope
+
+- Session replay (PostHog owns this, already self-hosted).
+- Product analytics funnels, retention cohorts, A/B flags — PostHog.
+- Heatmaps.
+- Mobile RUM.
+- Feature flag evaluation pre-merge.
+- Synthetic monitoring.
+
+### Acceptance criteria
+
+- [ ] Faro endpoint reachable at `https://obs.bravyr.com/collect`.
+- [ ] CORS restricts `Origin` to staging + prod domains; other origins receive 403.
+- [ ] Basic-auth enforced at Traefik layer (password = `FARO_APP_KEY`); unauthenticated requests rejected.
+- [ ] A browser click triggering a backend call appears as a single Tempo trace spanning browser span → Go handler span with matching `trace_id`.
+- [ ] Grafana dashboard renders p50/p75/p95 for each web-vital, grouped by route and release.
+- [ ] Sampling rate is runtime-configurable via SDK init (no rebuild).
+- [ ] No PII in payloads: no request bodies, no query strings with `token|key|auth|email`, IPs dropped before Loki write.
+- [ ] Source maps uploaded to private symbolicator; `.map` files never served publicly.
+- [ ] Tempo + Loki retention bumped to 14 days; disk growth alert in place.
+- [ ] `README.md` + integration guide updated; CHANGELOG entry added.
+
+### Risks / non-goals
+
+- **Cardinality explosion** if route/user/session promoted to Loki labels.
+- **GDPR** — IP + UA count as personal data in Loki; strip/hash at Alloy.
+- **Vendor lock** — Faro SDK is Grafana-flavoured but OTel-compatible. Non-React apps can swap to `@opentelemetry/sdk-trace-web` without backend changes.
+
+### Gap analysis
+
+Go library side: nothing missing. Existing OTel setup accepts W3C `traceparent` already. Stack-side gaps:
+
+1. Alloy config lacks `faro.receiver` component.
+2. No public ingress for browser traffic (stack is internal-only).
+3. No auth/CORS layer in front of Alloy.
+4. No RUM dashboard JSON.
+5. Tempo/Loki retention too short (72h) for frontend debugging workflows.
+6. No source-map resolution path.
+
+---
+
+## 2. Software Architect
+
+### Architecture
+
+```
+         [ Browser — socialup React ]
+                    |
+                    | HTTPS POST /collect
+                    | Authorization: Basic base64("faro:$FARO_APP_KEY")
+                    | Origin: https://socialup{-staging}.bravyr.com
+                    v
+         [ Coolify Traefik :443 ]
+         (TLS · basic-auth · CORS · rate-limit · 1 MB body cap)
+                    |
+                    | http://bravyr_alloy:12347/collect
+                    v
+      +-------- [ Alloy faro.receiver "frontend" ] --------+
+      |                 |                                  |
+ otelcol.exporter.otlp  loki.process.faro             (monitoring
+  → otel-collector:4317 → loki:3100                     network)
+      |                 |
+      v                 v
+  [ Tempo ]         [ Loki ]        [ Prometheus ]  [ Grafana ]
+                                      (unchanged)     (+ new RUM dash)
+```
+
+Alloy's `faro.receiver` has no native auth — Traefik terminates TLS and enforces basic-auth + CORS via Coolify labels. Alloy port `12347` stays on the internal `monitoring` network; Traefik is the only public entrypoint.
+
+### File changes
+
+- `stack/alloy/config.alloy` — extend with `faro.receiver "frontend"`, `loki.process "faro"`, `otelcol.exporter.otlp "tempo"`.
+- `stack/docker-compose.yaml` — add Coolify/Traefik labels on `alloy` service; add env vars for allowed origins + app key; depend on `otel-collector`.
+- `stack/tempo/config.yaml` — `block_retention` 72h → 14d; `max_block_bytes` 1 MB → 100 MB.
+- `stack/loki/config.yaml` — `retention_period` 72h → 14d; `ingestion_rate_mb` 8 → 32; `ingestion_burst_size_mb` 16 → 64.
+- `stack/.env.example` — add `FARO_ALLOWED_ORIGINS`, `FARO_APP_KEY`, `FARO_BASIC_AUTH_HTPASSWD`, `FARO_PUBLIC_HOST`.
+- `stack/grafana/dashboards/frontend-rum.json` (new) — web-vitals percentiles, JS errors/min, session counts, error table with Tempo trace links.
+- `docs/integration-guide.md` — frontend section with Faro SDK init + env-var contract.
+- `README.md` — features bullet list.
+- `CHANGELOG.md` — `## [Unreleased] → ### Added`.
+
+### Alloy config shape (sketch)
+
+```
+faro.receiver "frontend" {
+  server { listen_address = "0.0.0.0" listen_port = 12347
+           cors_allowed_origins = string.split(env("FARO_ALLOWED_ORIGINS"), ",") }
+  output { traces = [otelcol.exporter.otlp.tempo.input]
+           logs   = [loki.process.faro.receiver] }
+}
+otelcol.exporter.otlp "tempo" { client { endpoint = "otel-collector:4317"
+                                         tls { insecure = true } } }
+loki.process "faro" { /* drop query strings, strip IP, relabel route, structured_metadata for user_id/session_id */
+                      forward_to = [loki.write.loki.receiver] }
+```
+
+### Port & network topology
+
+| Component | Port | Binding |
+|-----------|------|---------|
+| Alloy Faro receiver | `12347` | `monitoring` network, internal-only |
+| Traefik (Coolify) | `443`, `80` | public, terminates TLS for `obs.bravyr.com` |
+| Tempo, Loki, Prom, OTel Collector | (unchanged) | internal |
+
+Dev overlay (`docker-compose.dev.yaml`) optionally publishes `127.0.0.1:12347:12347` for local testing without Coolify.
+
+### Env var contract (socialup)
+
+Naming follows `VITE_*` convention used by socialup:
+
+- `VITE_FARO_URL` — `https://obs.bravyr.com/collect`
+- `VITE_FARO_APP_NAME` — `socialup-web`
+- `VITE_FARO_APP_VERSION` — git SHA injected at build time
+- `VITE_FARO_ENVIRONMENT` — `development` | `staging` | `production`
+- `VITE_FARO_SAMPLE_RATE` — float 0.0–1.0 (default 0.1 prod, 1.0 otherwise)
+- `VITE_FARO_APP_KEY` — basic-auth password for ingest (per-env, rotatable)
+
+### Build sequence
+
+1. Stack changes (Alloy + compose + retention bumps) validated locally via `docker compose up`.
+2. Coolify labels wired; ACME cert provisioned for `obs.bravyr.com`.
+3. Dashboard JSON committed and provisioned.
+4. Docs updated; `make lint` / `make test` / `make swagger` pass.
+5. 5-agent pre-commit review; fix all findings.
+6. PR → merge → deploy to Coolify staging.
+7. Smoke test: curl from non-allowlisted origin → 403; allowlisted origin → 204.
+8. Separate PR in `socialup` repo: add `@grafana/faro-web-sdk` + `@grafana/faro-web-tracing`, init in `src/main.tsx`, wire env vars.
+
+### Decisions locked
+
+- Reverse proxy: **Coolify/Traefik** via container labels (no Caddy container).
+- Auth: **public write token** (basic-auth password), per-env, rotatable.
+- Sampling: **prod 100% errors / 10% page loads / 100% web-vitals; staging + dev 100% all**.
+- Retention bump: **included in this PR**.
+- Ingest domain: **obs.bravyr.com/collect**.
+
+---
+
+## 3. Security Specialist
+
+### Threat model
+
+| Threat | Control |
+|--------|---------|
+| DoS / disk-bill-shock | Traefik rate-limit (100 r/s burst, 20 r/s sustained per IP); 1 MB body cap; Loki ingestion ceiling |
+| Telemetry poisoning | Basic-auth + CORS allowlist + per-env token |
+| Session/credential exfil in error payloads | Faro `beforeSend` redacts `Authorization`, `Cookie`, `X-*-Token` headers; drops `request.body` / `response.body`; truncates stack at 4096 chars |
+| PII leak in URLs | `beforeSend` strips query strings; Alloy `stage.replace` as defence-in-depth |
+| SSRF via source-map fetch | Confirm Alloy v1.14 `faro.receiver` does not auto-fetch source maps; if it does, disable or restrict to internal allowlist |
+| CSRF | Not applicable — endpoint accepts no cookies |
+| Log injection into Loki | Dedicated `loki.process "faro"` pipeline; fixed `source=faro` label, payload fields never promoted to labels; variable fields go to structured metadata |
+
+### Auth model
+
+Public write token (`FARO_APP_KEY`), bundled into browser build, validated as basic-auth password at Traefik layer. Per-environment (`FARO_APP_KEY_STAGING`, `FARO_APP_KEY_PROD`). Rotation = Coolify env var update + socialup rebuild. **Never reuse `INTERNAL_API_KEY`** — that key has Prom remote-write scope and must stay server-only.
+
+### CORS
+
+Strict allowlist. No wildcards. Reject on mismatch.
+
+```
+Access-Control-Allow-Origin: https://socialup-staging.bravyr.com
+Access-Control-Allow-Origin: https://socialup.bravyr.com
+```
+
+Alloy `faro.receiver` `cors_allowed_origins` enforces at app layer; Traefik `headers` middleware enforces at edge as defence-in-depth.
+
+### TLS
+
+HTTPS-only. `Strict-Transport-Security: max-age=31536000; includeSubDomains`. ACME via Coolify/Traefik. Plain HTTP redirected to HTTPS.
+
+### Payload size limit
+
+1 MB body cap at Traefik (`maxRequestBodyBytes`). Return `413` on overage.
+
+### PII scrubbing (socialup repo)
+
+Faro `beforeSend` hook — highest-priority control for GDPR:
+
+- Strip query strings from all captured URLs.
+- Redact `Authorization`, `Cookie`, `X-Api-Key`, `X-Faro-*` header values in XHR breadcrumbs.
+- Drop `request.body` and `response.body` entirely.
+- Truncate `error.message` + `error.stack` at 4096 chars.
+- Replace user email with opaque user ID.
+
+### Source-map privacy
+
+Do **not** serve `.map` files from the socialup CDN. Upload to a private symbolicator keyed by release ID. Resolution happens server-side.
+
+### CSP
+
+socialup `Content-Security-Policy` must allow:
+
+```
+connect-src 'self' https://obs.bravyr.com;
+```
+
+### Data classification
+
+| Field | Store | Action |
+|-------|-------|--------|
+| Source IP | — | Drop at Alloy before Loki write |
+| User-Agent | Loki structured metadata | Keep |
+| User ID (opaque UUID) | Loki structured metadata | Keep |
+| URL path | Loki log body | Keep after query strip |
+| URL query string | — | Drop at Alloy (defence-in-depth) |
+| Error stack | Loki log body | Keep; Alloy `stage.replace` strips `Bearer `, `sk-`, `eyJ` prefixes |
+| Trace / span IDs | Tempo + Loki metadata | Keep |
+| Session ID | Loki structured metadata | Keep |
+| Request / response bodies | — | Drop at SDK + Alloy |
+
+### GDPR / retention
+
+Retention raised to 14 days in this PR (Tempo + Loki). Prom stays 30d (aggregates only). Document retention in privacy policy.
+
+### Dependency risk
+
+- Pin `@grafana/faro-web-sdk` + `@grafana/faro-web-tracing` to exact versions in socialup `package.json`.
+- Bundle (don't load from CDN) — no SRI needed.
+- `npm audit --audit-level=high` after install.
+- Confirm Alloy `v1.14.0` `faro.receiver` is non-experimental.
+
+### Open security items (follow-ups if required)
+
+- Alerting: Prom alert when Loki ingest rate from `source=faro` exceeds 5× baseline over 5 min.
+- Token rotation runbook: document in `docs/runbooks/`.
+
+---
+
+## 4. DBA / Storage
+
+### Current retention (verified from config)
+
+| Backend | Current | Target |
+|---------|---------|--------|
+| Tempo `block_retention` | 72 h | **14 d** |
+| Loki `retention_period` | 72 h | **14 d** |
+| Prometheus TSDB | 30 d | 30 d (unchanged) |
+| Tempo `max_block_bytes` | 1 MB | **100 MB** |
+| Loki `ingestion_rate_mb` | 8 | **32** |
+| Loki `ingestion_burst_size_mb` | 16 | **64** |
+
+Applied in this PR.
+
+### Cardinality
+
+| Label | Cardinality | Decision |
+|-------|-------------|----------|
+| `service` (`socialup-web`) | 1 | indexed label |
+| `environment` | 3 | indexed label |
+| `browser_name` | ~10 | indexed label |
+| `os_name` | ~6 | indexed label |
+| `release` | bounded by deploy cadence | indexed label |
+| `route` | **normalized** (`/user/:id`, not `/user/12345`) | indexed label (SDK normalizes, Alloy regex strips `/:id` + `/:uuid` as backstop) |
+| `url` (full) | unbounded | NEVER indexed; dropped before Loki write |
+| `user_id` | unbounded | structured metadata only |
+| `session_id` | unbounded | structured metadata only |
+
+Normalization applied in the Alloy `loki.process "faro"` pipeline via `stage.template` + `regexReplaceAll` for numeric segments and UUID paths. The Faro SDK `beforeSend` hook normalizes too (belt + braces). Dashboard `by (route)` aggregations rely on `route` being a stream label — if this is ever demoted back to structured metadata, update the dashboard in the same PR.
+
+### Volume estimate (10k DAU baseline, post-sampling)
+
+```
+10,000 DAU × 5 sessions × 20 events = 1,000,000 events/day
+Avg log line                         ~500 B
+Raw log volume                       ~500 MB/day
+Loki compressed (~5:1)               ~100 MB/day
+14-day Loki total                    ~1.4 GB
+
+Traces @ 10% sampling               100,000/day
+Avg trace size                       ~1 KB
+Tempo raw                            ~100 MB/day
+14-day Tempo total                   ~1.4 GB
+
+Prom (web-vitals)                   <500 new series, <50 MB/30d
+```
+
+Total new disk demand ≈ **3 GB** at 14-day retention. Coolify VPS disk budget adequate; add `node_filesystem_avail_bytes` alert before ship.
+
+### Sampling
+
+Applied at the Faro SDK transport layer, not backend.
+
+| Env | Errors | Page loads | Web-vitals |
+|-----|--------|-----------|------------|
+| Prod | 100% | 10% | 100% |
+| Staging | 100% | 100% | 100% |
+| Dev | 100% | 100% | 100% |
+
+Tempo `metrics_generator` already runs `span-metrics` + `service-graphs` — frontend spans feed those automatically.
+
+### Query patterns
+
+```promql
+-- LCP p95 by route
+histogram_quantile(0.95, rate(faro_web_vitals_lcp_bucket[5m])) by (route)
+
+-- Error rate by browser
+rate(faro_errors_total[5m]) by (browser_name, environment)
+
+-- JS error volume (Loki)
+sum by (route) (count_over_time({service="socialup-web", level="error"}[5m]))
+```
+
+All grouping labels must exist as Prom metric labels / Loki stream labels — `route` normalization is the critical prerequisite.
+
+### Risks
+
+1. **Route cardinality bomb** — highest-probability failure. SPA with dynamic IDs → O(users) unique `route` values within hours. Enforce normalization in Alloy before write.
+2. **Disk-full cascade** — shared Docker volume pool. Add `node_filesystem_avail_bytes` alert.
+3. **Tempo tiny-block accumulation** — current 1 MB block size produces thousands of blocks/day at frontend scale. Bumped to 100 MB in this PR.
+4. **Loki unauthenticated write path** — `auth_enabled: false` is acceptable because Alloy is the only client on the internal network and the Traefik ingress enforces auth. Document this invariant.
+
+---
+
+## 5. Deferred / follow-up issues
+
+Create GitHub issues (per "Deferred Work Policy") for:
+
+- Source-map private symbolicator setup + build-time upload pipeline (socialup side).
+- Disk-full + `source=faro` ingest-rate Prom alerts.
+- Token rotation runbook.
+- socialup SDK integration PR (separate plan).

--- a/docs/plans/010-host-bind-mounts.md
+++ b/docs/plans/010-host-bind-mounts.md
@@ -1,0 +1,245 @@
+# 010 — Host Bind-Mount Persistence + Grafana 504 Diagnostics
+
+## Context
+
+`bravyr-obs` runs as a self-hosted Coolify stack on a single VPS. Two operational pains drive this work:
+
+1. **Data loss on redeploy.** All five backend volumes (`prometheus_data`, `tempo_data`, `grafana_data`, `loki_data`, `alloy_data`) are unnamed Docker volumes. Coolify recreate operations have wiped the `alloy_data` volume in the past, which triggered a Loki "entry too far behind" log storm (`loki.source.docker` re-read every container log from byte zero, posting timestamps from 8+ days ago into ingesters whose `max_chunk_age` is 2h). The same vector also risks losing Prometheus TSDB, Tempo blocks, Loki chunks, and Grafana dashboards/users.
+2. **Recurring Grafana 504 Gateway Timeout — root cause is the Coolify Traefik edge, not the obs stack.** Empirically the 504 cleared the moment the user redeployed an unrelated service in Coolify, without touching the observability stack. Coolify regenerates Traefik labels and reloads its config on any deploy, so any one of: stale router pointing at a dead upstream IP, broken healthcheck, dead persistent TCP connections in Traefik's upstream pool, or Coolify-managed certificate / route reconcile lag would clear on that reload. We do not have Traefik logs from the failure window, so this PR instruments the next occurrence rather than guessing at a fix.
+
+Intended outcome: a Coolify redeploy preserves all five datastores; the next Grafana 504 surfaces as an alert with the diagnostic data needed to root-cause it (instead of a redeploy ritual); the Loki single-replica ring stops blocking Grafana queries on restart.
+
+## Decisions Locked
+
+- **Data root**: `/srv/bravyr-obs/data` on the Coolify host.
+- **Backup**: none in this PR. Bind mounts already survive Coolify redeploys. Dashboards + datasources live in git. 14d of metrics/logs/traces is forensics-only — acceptable to lose if the VPS dies. Off-site backup deferred to a tracked follow-up issue, to be revisited when a customer-facing SLO needs it.
+- **Loki "entry too far behind" fix** (today's log storm): folded into open PR #43 (Alloy `stage.drop { older_than = "1h" }`). This plan starts on a fresh branch after PR #43 merges.
+- **Grafana admin password rotation**: no. Hash never left the named volume; no realistic exposure path. Keep current password. New `0600` perms on `grafana.db` after cutover lock down the file.
+- **Bootstrap fail-fast on UID mismatch**: yes — refuse, do not auto-chown.
+- **Pre-cutover tarball snapshot of current named volumes**: yes — one-shot insurance during cutover, stored under `/srv/bravyr-obs/backups/pre-cutover/`. Pruned after 14 days. No ongoing backup beyond this.
+
+## Architecture
+
+Host directory layout under a single base path. Each subdirectory is owned by the container UID that writes it.
+
+```
+/srv/bravyr-obs/
+├── data/                                       # STACK_DATA_ROOT
+│   ├── prometheus/   65534:bravyr-obs   0750   # Prom TSDB → /prometheus
+│   ├── tempo/        10001:bravyr-obs   0750   # blocks + WAL → /var/tempo
+│   ├── loki/         10001:bravyr-obs   0750   # chunks + tsdb index → /loki
+│   ├── grafana/      472:bravyr-obs     0750   # sqlite + plugins → /var/lib/grafana
+│   │   └── grafana.db                  0600
+│   └── alloy/        473:bravyr-obs     0750   # positions + WAL → /var/lib/alloy/data
+└── backups/                            0700    # root:root
+    └── pre-cutover/                            # one-time tarballs of named volumes (pruned after 14d)
+```
+
+`bravyr-obs` is a host group created by the bootstrap script. Top-level `/srv/bravyr-obs` is `0750 root:bravyr-obs`.
+
+Filesystem requirements: ext4 or xfs with journaling, mounted with `noatime`. SSD strongly preferred for Prom + Loki query latency. Recommend a dedicated 50 GB partition or LV at `/srv/bravyr-obs/data`.
+
+## File Changes
+
+| Path | Purpose |
+|------|---------|
+| `stack/docker-compose.yaml` | Replace 5 named volumes with bind mounts under `${STACK_DATA_ROOT}/<svc>`. Tighten Grafana healthcheck. Add `blackbox-exporter` service. |
+| `stack/.env.example` | Add `STACK_DATA_ROOT=/srv/bravyr-obs/data`, `BLACKBOX_TARGETS` (comma-separated public URLs Prom should probe). |
+| `stack/loki/config.yaml` | Pin instance identity to loopback so single-replica ring forms synchronously on restart (sec **Loki ring fix**). |
+| `stack/blackbox-exporter/config.yaml` *(new)* | `http_2xx` probe module with 5s timeout. |
+| `stack/prometheus/prometheus.yml` | Add `blackbox` scrape job covering Grafana public URL (and Faro `/collect`). Reference `rule_files`. |
+| `stack/prometheus/rules/edge-health.yaml` *(new)* | Alerts: `GrafanaEdgeUnreachable`, `GrafanaEdgeLatencyHigh`. |
+| `stack/grafana/provisioning/datasources/datasources.yaml` | Add `jsonData.timeout: 60` to Loki and Tempo (defensive hygiene). |
+| `stack/scripts/bootstrap-host-dirs.sh` *(new)* | Idempotent first-boot host directory creation. Refuses on UID mismatch or path traversal. |
+| `stack/scripts/migrate-volumes-to-bind.sh` *(new)* | One-shot cutover: tarball each named volume into `pre-cutover/`, then `cp -a` into the bind path with correct ownership. |
+| `docs/coolify-deployment.md` | Replace named-volume language with bootstrap + bind-mount cutover runbook + Grafana 504 diagnosis runbook. |
+| `CHANGELOG.md` | `### Changed` entry. |
+
+## Bind-Mount Cutover (live deployment)
+
+Run from the Coolify host shell. **Take the pre-cutover tarball before anything else.**
+
+1. SSH to the host. Place the new `bootstrap-host-dirs.sh` and run it. It validates `STACK_DATA_ROOT`, creates the `bravyr-obs` group, creates each subdirectory with the right UID and `0750`, refuses if any target already exists with UID 0.
+2. `docker compose stop` (not `down` — keeps named volumes for the copy step). Use SIGTERM to flush WAL on Prom, Loki, Tempo.
+3. Pre-cutover tarball:
+   ```bash
+   for v in prometheus tempo loki grafana alloy; do
+     docker run --rm \
+       -v "bravyr-obs_${v}_data:/src:ro" \
+       -v /srv/bravyr-obs/backups/pre-cutover:/dst \
+       alpine tar czf "/dst/${v}-$(date +%F).tar.gz" -C /src .
+   done
+   ```
+4. Per-volume copy with ownership (run from `migrate-volumes-to-bind.sh`):
+   ```bash
+   docker run --rm -v bravyr-obs_prometheus_data:/src \
+     -v /srv/bravyr-obs/data/prometheus:/dst alpine sh -c \
+     "cp -a /src/. /dst/ && chown -R 65534:65534 /dst"
+   # repeat per service: tempo→10001, loki→10001, grafana→472, alloy→473
+   ```
+5. Merge the PR. Coolify pulls and recreates with the new `docker-compose.yaml`. Bind mounts attach to the populated host paths.
+6. Verify (sec **Verification**).
+7. After 24h of clean operation: `docker volume rm bravyr-obs_{prometheus,tempo,loki,grafana,alloy}_data`. Tarballs stay in `pre-cutover/` for 14 days then are pruned.
+
+## Grafana 504 — Diagnosis-First, No Speculative Fix
+
+The 504 the user sees is **browser → Coolify Traefik → Grafana** failing at the edge proxy hop. It clears the moment any service in Coolify gets redeployed, which makes Coolify regenerate Traefik labels and reload its config. The observability stack itself is healthy; the underlying datasource queries succeed once a fresh request gets through.
+
+Root cause sits in Coolify's Traefik / proxy state — almost certainly one of:
+
+- Stale router pointing at a dead upstream IP after a previous Grafana restart, never re-resolved.
+- Broken healthcheck causing Traefik to mark Grafana unhealthy and fall back to nothing.
+- Dead persistent TCP connections in Traefik's upstream pool, kept alive past the container's actual lifetime.
+- Coolify-managed certificate or route reconcile lag.
+
+We do not have Traefik logs from the failure window. Without those, fixing this preemptively is guessing. The plan therefore instruments so the next occurrence surfaces with the data needed to root-cause, instead of being a guess-and-redeploy ritual.
+
+Concrete actions in this PR:
+
+1. **Strengthen Grafana's container healthcheck** so Coolify (and any future probe) can distinguish "process up" from "API responsive". `stack/docker-compose.yaml` already has a healthcheck hitting `/api/health`; bump frequency and tighten the failure threshold so Coolify reacts within seconds instead of minutes:
+   ```yaml
+   healthcheck:
+     test: ["CMD-SHELL", "wget -qO- http://localhost:3000/api/health || exit 1"]
+     interval: 15s
+     timeout: 3s
+     retries: 3
+     start_period: 30s
+   ```
+2. **External blackbox probe** of `https://grafana.bravyr.com/api/health` from outside Docker. Add `prom/blackbox-exporter` to the stack and a Prom job that hits the public URL. When Grafana is reachable internally but 504s externally, `probe_success` flips to 0 and an alert fires — that's the exact failure mode the user sees.
+   - New file: `stack/blackbox-exporter/config.yaml` with an `http_2xx` module.
+   - New file: `stack/prometheus/rules/edge-health.yaml` with `GrafanaEdgeUnreachable` and `GrafanaEdgeLatencyHigh` alerts.
+   - Compose service `blackbox-exporter` on the monitoring network.
+   - Prom scrape job pointed at the public Grafana URL (and any other public-facing observability endpoint, e.g. `https://obs.bravyr.com/collect`).
+3. **Diagnosis runbook** (add to `docs/coolify-deployment.md`):
+   - First, **don't redeploy yet** — that destroys the evidence.
+   - From the host: `docker logs $(docker ps -q --filter name=coolify-proxy) --tail 200` — capture what Traefik says about the Grafana router right now.
+   - `docker exec coolify-proxy wget -qO- http://bravyr_grafana:3000/api/health` — confirms internal health from inside Traefik's container. If this returns 200, the issue is purely in Traefik's edge handling.
+   - `curl -v https://grafana.bravyr.com/api/health` from your laptop — capture the actual upstream error Traefik reports.
+   - Inspect Traefik's API: `curl -s http://localhost:8080/api/http/routers | jq '.[] | select(.service | contains("grafana"))'` (port 8080 is Traefik's internal API; may need port-forward).
+   - Once data is captured, trigger a Coolify "redeploy proxy" (not the whole stack) to force Traefik label reload — this is the smallest intervention that fixes the symptom.
+   - File the captured logs as a follow-up issue so the next occurrence has comparison data.
+4. **Datasource timeouts (defensive only)** — small hygiene unrelated to the 504 root cause but worth doing while we're in this file. Add `jsonData.timeout: 60` to Loki and Tempo in `stack/grafana/provisioning/datasources/datasources.yaml` so legitimately slow queries fail with a Grafana error message rather than a generic stack-trace.
+
+**Out of scope for this PR**: changing Coolify's Traefik config, adding `dataproxy` overrides, or building a custom edge proxy. The user's confirmed evidence shows defaults work; we just need to detect when they stop.
+
+## Loki Single-Replica Ring Fix
+
+Symptom: `empty ring` and `context canceled` warnings during restart, blocking Grafana queries until Loki's ring re-stabilises. Cause: Coolify bridge hostnames are unstable across restarts; the ingester registers under a name it cannot re-resolve, so the ring stays empty.
+
+Add to `stack/loki/config.yaml`:
+
+```yaml
+common:
+  instance_addr: 127.0.0.1
+  ring:
+    kvstore:
+      store: inmemory
+    instance_addr: 127.0.0.1
+memberlist:
+  bind_addr: ["127.0.0.1"]
+  join_members: []
+```
+
+With `replication_factor: 1` + inmemory KV + loopback, ring formation completes synchronously at boot. No empty-ring window, no early Grafana queries fanning into the 504 path.
+
+## Tempo Timeouts
+
+Skipped. Tempo defaults are fine; the Grafana 504 was a Coolify-Traefik edge issue, not a Tempo stall. Revisit only if a Tempo-specific stall surfaces after the blackbox probe is in place.
+
+## Bootstrap Script
+
+`stack/scripts/bootstrap-host-dirs.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${STACK_DATA_ROOT:?STACK_DATA_ROOT must be set}"
+
+case "$ROOT" in /*) ;; *) echo "STACK_DATA_ROOT must be absolute" >&2; exit 1 ;; esac
+[[ "$ROOT" == *..* ]] && { echo "Path traversal detected" >&2; exit 1; }
+resolved=$(realpath -m "$ROOT")
+[[ "$resolved" == /srv/* ]] || { echo "Must resolve under /srv/" >&2; exit 1; }
+
+groupadd -f bravyr-obs
+gid=$(getent group bravyr-obs | cut -d: -f3)
+
+declare -A DIR_UIDS=(
+  [prometheus]=65534
+  [tempo]=10001
+  [loki]=10001
+  [grafana]=472
+  [alloy]=473
+)
+
+for name in "${!DIR_UIDS[@]}"; do
+  uid="${DIR_UIDS[$name]}"
+  dir="$ROOT/$name"
+  mkdir -p "$dir"
+  owner=$(stat -c '%u' "$dir")
+  if [[ "$owner" -ne 0 && "$owner" -ne "$uid" ]]; then
+    echo "$dir is owned by UID $owner — refusing to start (expected $uid)" >&2
+    exit 1
+  fi
+  if [[ "$owner" -eq 0 && -n "$(ls -A "$dir" 2>/dev/null)" ]]; then
+    echo "$dir is owned by UID 0 and non-empty — refusing to chown" >&2
+    exit 1
+  fi
+  chown "$uid:$gid" "$dir"
+  chmod 0750 "$dir"
+done
+
+[[ -f "$ROOT/grafana/grafana.db" ]] && chmod 0600 "$ROOT/grafana/grafana.db"
+
+mkdir -p /srv/bravyr-obs/backups/pre-cutover
+chmod 0700 /srv/bravyr-obs/backups
+chown root:"$gid" /srv/bravyr-obs/backups
+
+chmod 0750 /srv/bravyr-obs
+chown root:"$gid" /srv/bravyr-obs
+```
+
+## Build Sequence
+
+1. **Branch off `main` after PR #43 merges**: `feature/010-host-bind-mounts`. PR #43 carries the Alloy `stage.drop { older_than = "1h" }` patch separately.
+2. Implement compose, Loki ring config, datasource timeouts, blackbox-exporter + edge-health alert rules, bootstrap + migration scripts, docs, CHANGELOG.
+3. Run pre-commit checks: `make swagger`, `make lint`, `make test`.
+4. Run the 5 pre-commit review agents (code-reviewer, qa, security, software-architect, dba) per CLAUDE.md. Fix all findings.
+5. Open PR with `--assignee brunosansigolo` and labels copied from the linked issue (or `enhancement` if none).
+6. SSH to Coolify host. Run `bootstrap-host-dirs.sh`. Confirm dirs exist with right UIDs.
+7. Add Coolify secret: `STACK_DATA_ROOT=/srv/bravyr-obs/data`, plus `BLACKBOX_TARGETS` for the public probe URL(s).
+8. Merge PR. Coolify redeploys.
+9. Run cutover script: tarball each named volume into `pre-cutover/`, then `cp -a` into the bind path.
+10. Coolify reconciles → bind mounts attach to populated dirs.
+11. Smoke test (sec **Verification**).
+12. After 24h clean: drop old named volumes.
+13. Create follow-up GitHub issues for: disk-usage alert at 70% / 85% on `/srv/bravyr-obs/data`, off-site backup (revisit when SLO requires), optional LUKS at-rest encryption decision.
+
+## Verification
+
+End-to-end checks after the cutover deploys:
+
+- **Persistence sanity**: stop the stack with `docker compose stop`, confirm `ls -la /srv/bravyr-obs/data/{prometheus,tempo,loki,grafana,alloy}` is non-empty with the expected UID owner. `docker compose start`. Grafana, Tempo, Loki, Prom resume serving without re-ingesting from zero.
+- **Prometheus continuity**: in Grafana **Explore → Prometheus**, query `up{}` over the last 7 days. The line is continuous across the cutover timestamp with no gap longer than the cutover window.
+- **Loki continuity**: `{service=~".+"} | __error__=""` over the last 7 days returns logs from before the cutover. No new "entry too far behind" lines after Alloy restart (PR #43 fix).
+- **Tempo continuity**: open a trace ID generated yesterday in Grafana **Explore → Tempo**. Spans render.
+- **Grafana state**: dashboards, datasources, users, API keys all present. Existing admin password still works (no rotation).
+- **Alloy positions**: `docker compose stop alloy && docker compose start alloy`, then check Loki for any lines older than 5 minutes from any container — there should be none. Positions resumed cleanly.
+- **Grafana 504 instrumentation**: blackbox-exporter scrapes successfully against the Grafana public URL. `probe_success` returns 1. Manually flip Grafana off (`docker compose stop grafana`) and confirm `GrafanaEdgeUnreachable` fires within 2 minutes. Restart Grafana, alert resolves.
+- **Loki ring**: `curl -s http://loki:3100/ring` from inside the network returns a populated ring within 5s of container start, never stays empty.
+- **Permissions**: `stat -c '%U:%G %a' /srv/bravyr-obs/data/grafana/grafana.db` returns `<grafana_uid>:bravyr-obs 600`.
+- **Pre-cutover tarballs**: `ls -la /srv/bravyr-obs/backups/pre-cutover/` shows one tarball per service from cutover day. Manual `tar tzf` smoke check on one of them confirms readability.
+- **Fail-fast**: as a separate test, `chown root /srv/bravyr-obs/data/loki && bootstrap-host-dirs.sh` should exit non-zero with a clear message. Restore correct ownership after.
+
+## Out of Scope (follow-ups)
+
+- Multi-node / HA Loki / Tempo (distributor + ingester + querier split).
+- S3/GCS object-store backend for Loki / Tempo (currently filesystem).
+- Hot/cold tiering and long-term retention beyond 14d.
+- Loki multi-tenancy (`auth_enabled: true`) and per-tenant rate limits.
+- Off-site backup of the data root (e.g. restic + R2/B2). Defer until a customer-facing SLO requires retained obs data after a VPS-loss event. Today the only irreplaceable bits are dashboards/datasources, which already live in git.
+- Automated DR rehearsal as a scheduled job (no DR plan to rehearse until backup ships).
+- LUKS at-rest encryption on the data partition (defer until customer PII lands in Loki).
+- Disk-usage Prometheus alert at 70% / 85% on the `/srv/bravyr-obs/data` mount — already tracked as a deferred-work issue from PR #43; tighten to also watch the new mount.
+
+Each of the above gets a tracked GitHub issue per the deferred-work policy if it isn't already covered by the existing #44–#49 set.

--- a/stack/.env.example
+++ b/stack/.env.example
@@ -8,3 +8,34 @@ GRAFANA_ADMIN_PASSWORD=CHANGEME
 # Internal API key for Prometheus to scrape /metrics endpoints.
 # Must match INTERNAL_API_KEY set in the socialup-api Coolify env vars.
 INTERNAL_API_KEY=CHANGEME
+
+# ---------------------------------------------------------------------------
+# Frontend observability (Grafana Faro) — browser RUM ingest at
+# https://obs.bravyr.com/collect. Public endpoint, basic-auth + CORS
+# enforced by Coolify/Traefik.
+# ---------------------------------------------------------------------------
+
+# Public FQDN Traefik routes /collect for. Must have a TLS cert provisioned
+# in Coolify (Let's Encrypt).
+FARO_PUBLIC_HOST=obs.bravyr.com
+
+# Comma-separated origin allowlist enforced by Alloy faro.receiver.
+# Must exactly match the socialup Origin header(s) — no trailing slashes,
+# no wildcards. Example for staging + prod:
+FARO_ALLOWED_ORIGINS=https://socialup-staging.bravyr.com,https://socialup.bravyr.com
+
+# Shared secret that the socialup build ships to browsers as the Faro
+# basic-auth password. Treat as low-trust: CORS + rate limit are the real
+# defence; the token exists for per-env revocation. Rotate quarterly.
+FARO_APP_KEY=CHANGEME
+
+# Bcrypt htpasswd line for the basic-auth middleware. Generate once per
+# rotation with:
+#   htpasswd -nbB faro "$FARO_APP_KEY"
+# CRITICAL: escape EVERY literal `$` as `$$` before pasting here, or
+# Docker Compose will silently interpolate `$2y$...` as empty variables,
+# leaving Traefik with an empty password that accepts any credential.
+# The line must start with `faro:$2y$` (or `faro:$2b$`) after interpolation.
+# Example (fake hash — do not use):
+#   FARO_BASIC_AUTH_HTPASSWD=faro:$$2y$$05$$qK…
+FARO_BASIC_AUTH_HTPASSWD=CHANGEME

--- a/stack/alloy/config.alloy
+++ b/stack/alloy/config.alloy
@@ -1,8 +1,21 @@
-// Grafana Alloy configuration for log collection.
-// Replaces Promtail (EOL March 2026).
-// Discovers Docker containers, parses JSON logs, extracts labels,
-// and ships to Loki.
+// Grafana Alloy configuration for the bravyr-obs stack.
+//
+// Responsibilities:
+//   1. Discover Docker containers and ship stdout JSON logs to Loki.
+//   2. Receive frontend telemetry from Grafana Faro Web SDK (traces + logs
+//      + events + measurements) and fan out to Tempo (via OTel Collector)
+//      and Loki.
+//
+// The faro.receiver listens on an internal-only port. Public exposure,
+// TLS, basic-auth, CORS and rate limiting are enforced upstream by
+// Coolify/Traefik against https://obs.bravyr.com/collect. The `monitoring`
+// Docker network is treated as a trust boundary — any container on it can
+// reach port 12347 directly, so the Alloy-side rate limit acts as an
+// absolute backstop below the Traefik limit.
 
+// ---------------------------------------------------------------------------
+// Docker log collection (replaces Promtail, EOL March 2026).
+// ---------------------------------------------------------------------------
 discovery.docker "containers" {
   host = "unix:///var/run/docker.sock"
   refresh_interval = "5s"
@@ -58,4 +71,138 @@ loki.write "loki" {
   endpoint {
     url = "http://loki:3100/loki/api/v1/push"
   }
+}
+
+// ---------------------------------------------------------------------------
+// Frontend RUM — Grafana Faro Web SDK ingest.
+// Port 12347 is bound to the monitoring network only (no Docker `ports:`
+// mapping). Auth + CORS + rate limiting are enforced by Traefik at
+// https://obs.bravyr.com/collect. The Alloy-side rate limit (20 r/s, burst
+// 100) matches the Traefik middleware so a caller who reaches Alloy
+// directly from inside the Docker network cannot exceed the edge limit.
+// ---------------------------------------------------------------------------
+faro.receiver "frontend" {
+  server {
+    listen_address           = "0.0.0.0"
+    listen_port              = 12347
+    cors_allowed_origins     = string.split(sys.env("FARO_ALLOWED_ORIGINS"), ",")
+    max_allowed_payload_size = "1MiB"
+
+    rate_limiting {
+      enabled    = true
+      rate       = 20
+      burst_size = 100
+    }
+  }
+
+  // Source-map symbolication intentionally omitted: Alloy's `sourcemaps`
+  // block auto-fetches `.map` files over HTTP and is an SSRF vector
+  // without an explicit allowlist. Resolve stacks offline instead.
+
+  output {
+    traces = [otelcol.exporter.otlp.tempo.input]
+    logs   = [loki.process.faro.receiver]
+  }
+}
+
+// Forward browser traces into the same OTel Collector used by backend
+// services so correlation by traceparent works out of the box.
+otelcol.exporter.otlp "tempo" {
+  client {
+    endpoint = "otel-collector:4317"
+    tls {
+      insecure = true
+    }
+  }
+}
+
+// Dedicated Loki pipeline for Faro payloads. Extracts bounded fields from
+// the payload JSON and promotes them to indexed labels; keeps unbounded
+// identifiers in structured metadata; scrubs credential-shaped substrings
+// as defence-in-depth.
+loki.process "faro" {
+  // Extract fields from the Faro payload emitted by faro.receiver.
+  stage.json {
+    expressions = {
+      kind       = "kind",
+      app        = "meta.app.name",
+      env        = "meta.app.environment",
+      release    = "meta.app.version",
+      browser    = "meta.browser.name",
+      os         = "meta.browser.os",
+      session_id = "meta.session.id",
+      user_id    = "meta.user.id",
+      trace_id   = "meta.trace.trace_id",
+      route      = "meta.view.name",
+    }
+  }
+
+  // Route normalization (defence-in-depth). The SDK beforeSend hook
+  // should already emit templated routes (e.g. "/user/:id"). These
+  // regex replacements strip numeric and UUID path segments that
+  // slip through, keeping cardinality bounded.
+  stage.template {
+    source   = "route"
+    template = "{{ regexReplaceAll `/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}` .Value `/:uuid` }}"
+  }
+  stage.template {
+    source   = "route"
+    template = "{{ regexReplaceAll `/[0-9]+` .Value `/:id` }}"
+  }
+
+  stage.static_labels {
+    values = {
+      source = "faro",
+    }
+  }
+
+  // Bounded, low-cardinality fields → indexed labels.
+  stage.labels {
+    values = {
+      app     = "",
+      kind    = "",
+      env     = "",
+      browser = "",
+      os      = "",
+      route   = "",
+    }
+  }
+
+  // High-cardinality identifiers → structured metadata (filterable, not
+  // indexed). Requires Loki >= 3.6 and `allow_structured_metadata: true`.
+  stage.structured_metadata {
+    values = {
+      user_id    = "",
+      session_id = "",
+      trace_id   = "",
+      release    = "",
+    }
+  }
+
+  // Defence-in-depth credential scrubbing. The Faro SDK beforeSend
+  // hook is the primary control; these stages catch anything that
+  // slips through. Bearer allows the full Base64 alphabet (incl.
+  // `+` `/` `=`) plus the URL-safe alternates used by JWTs.
+  stage.replace {
+    expression = "(Bearer\\s+)[A-Za-z0-9._+/=\\-]+"
+    replace    = "$1[REDACTED]"
+  }
+  stage.replace {
+    expression = "(sk-)[A-Za-z0-9]{16,}"
+    replace    = "$1[REDACTED]"
+  }
+  stage.replace {
+    expression = "(eyJ)[A-Za-z0-9._+/=\\-]{16,}"
+    replace    = "$1[REDACTED]"
+  }
+
+  // Strip common IP-shaped fields so Loki never stores the client
+  // address. Faro payloads and any forwarded headers picked up by the
+  // receiver are both covered by matching the JSON value form.
+  stage.replace {
+    expression = "\"(client_ip|remote_addr|remoteAddr|ip|x_forwarded_for)\":\\s*\"[^\"]+\""
+    replace    = "\"$1\":\"[REDACTED]\""
+  }
+
+  forward_to = [loki.write.loki.receiver]
 }

--- a/stack/alloy/config.alloy
+++ b/stack/alloy/config.alloy
@@ -17,60 +17,60 @@
 // Docker log collection (replaces Promtail, EOL March 2026).
 // ---------------------------------------------------------------------------
 discovery.docker "containers" {
-  host = "unix:///var/run/docker.sock"
-  refresh_interval = "5s"
+	host             = "unix:///var/run/docker.sock"
+	refresh_interval = "5s"
 }
 
 discovery.relabel "containers" {
-  targets = discovery.docker.containers.targets
+	targets = discovery.docker.containers.targets
 
-  // Use the container name as the "container" label.
-  rule {
-    source_labels = ["__meta_docker_container_name"]
-    regex         = "/(.*)"
-    target_label  = "container"
-  }
+	// Use the container name as the "container" label.
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.*)"
+		target_label  = "container"
+	}
 }
 
 loki.source.docker "containers" {
-  host       = "unix:///var/run/docker.sock"
-  targets    = discovery.relabel.containers.output
-  forward_to = [loki.process.pipeline.receiver]
+	host       = "unix:///var/run/docker.sock"
+	targets    = discovery.relabel.containers.output
+	forward_to = [loki.process.pipeline.receiver]
 }
 
 loki.process "pipeline" {
-  // Parse JSON log lines from zerolog output.
-  stage.json {
-    expressions = {
-      level    = "level",
-      service  = "service",
-      trace_id = "trace_id",
-    }
-  }
+	// Parse JSON log lines from zerolog output.
+	stage.json {
+		expressions = {
+			level    = "level",
+			service  = "service",
+			trace_id = "trace_id",
+		}
+	}
 
-  // Promote low-cardinality fields to indexed labels.
-  stage.labels {
-    values = {
-      level   = "",
-      service = "",
-    }
-  }
+	// Promote low-cardinality fields to indexed labels.
+	stage.labels {
+		values = {
+			level   = "",
+			service = "",
+		}
+	}
 
-  // Store trace_id as structured metadata (filterable, not indexed).
-  // Requires Loki >= 3.6 (fixed in 3.5.1+).
-  stage.structured_metadata {
-    values = {
-      trace_id = "",
-    }
-  }
+	// Store trace_id as structured metadata (filterable, not indexed).
+	// Requires Loki >= 3.6 (fixed in 3.5.1+).
+	stage.structured_metadata {
+		values = {
+			trace_id = "",
+		}
+	}
 
-  forward_to = [loki.write.loki.receiver]
+	forward_to = [loki.write.loki.receiver]
 }
 
 loki.write "loki" {
-  endpoint {
-    url = "http://loki:3100/loki/api/v1/push"
-  }
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -82,38 +82,39 @@ loki.write "loki" {
 // directly from inside the Docker network cannot exceed the edge limit.
 // ---------------------------------------------------------------------------
 faro.receiver "frontend" {
-  server {
-    listen_address           = "0.0.0.0"
-    listen_port              = 12347
-    cors_allowed_origins     = string.split(sys.env("FARO_ALLOWED_ORIGINS"), ",")
-    max_allowed_payload_size = "1MiB"
+	server {
+		listen_address           = "0.0.0.0"
+		listen_port              = 12347
+		cors_allowed_origins     = string.split(sys.env("FARO_ALLOWED_ORIGINS"), ",")
+		max_allowed_payload_size = "1MiB"
 
-    rate_limiting {
-      enabled    = true
-      rate       = 20
-      burst_size = 100
-    }
-  }
+		rate_limiting {
+			enabled    = true
+			rate       = 20
+			burst_size = 100
+		}
+	}
 
-  // Source-map symbolication intentionally omitted: Alloy's `sourcemaps`
-  // block auto-fetches `.map` files over HTTP and is an SSRF vector
-  // without an explicit allowlist. Resolve stacks offline instead.
+	// Source-map symbolication intentionally omitted: Alloy's `sourcemaps`
+	// block auto-fetches `.map` files over HTTP and is an SSRF vector
+	// without an explicit allowlist. Resolve stacks offline instead.
 
-  output {
-    traces = [otelcol.exporter.otlp.tempo.input]
-    logs   = [loki.process.faro.receiver]
-  }
+	output {
+		traces = [otelcol.exporter.otlp.tempo.input]
+		logs   = [loki.process.faro.receiver]
+	}
 }
 
 // Forward browser traces into the same OTel Collector used by backend
 // services so correlation by traceparent works out of the box.
 otelcol.exporter.otlp "tempo" {
-  client {
-    endpoint = "otel-collector:4317"
-    tls {
-      insecure = true
-    }
-  }
+	client {
+		endpoint = "otel-collector:4317"
+
+		tls {
+			insecure = true
+		}
+	}
 }
 
 // Dedicated Loki pipeline for Faro payloads. Extracts bounded fields from
@@ -121,88 +122,91 @@ otelcol.exporter.otlp "tempo" {
 // identifiers in structured metadata; scrubs credential-shaped substrings
 // as defence-in-depth.
 loki.process "faro" {
-  // Extract fields from the Faro payload emitted by faro.receiver.
-  stage.json {
-    expressions = {
-      kind       = "kind",
-      app        = "meta.app.name",
-      env        = "meta.app.environment",
-      release    = "meta.app.version",
-      browser    = "meta.browser.name",
-      os         = "meta.browser.os",
-      session_id = "meta.session.id",
-      user_id    = "meta.user.id",
-      trace_id   = "meta.trace.trace_id",
-      route      = "meta.view.name",
-    }
-  }
+	// Extract fields from the Faro payload emitted by faro.receiver.
+	stage.json {
+		expressions = {
+			kind       = "kind",
+			app        = "meta.app.name",
+			env        = "meta.app.environment",
+			release    = "meta.app.version",
+			browser    = "meta.browser.name",
+			os         = "meta.browser.os",
+			session_id = "meta.session.id",
+			user_id    = "meta.user.id",
+			trace_id   = "meta.trace.trace_id",
+			route      = "meta.view.name",
+		}
+	}
 
-  // Route normalization (defence-in-depth). The SDK beforeSend hook
-  // should already emit templated routes (e.g. "/user/:id"). These
-  // regex replacements strip numeric and UUID path segments that
-  // slip through, keeping cardinality bounded.
-  stage.template {
-    source   = "route"
-    template = "{{ regexReplaceAll `/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}` .Value `/:uuid` }}"
-  }
-  stage.template {
-    source   = "route"
-    template = "{{ regexReplaceAll `/[0-9]+` .Value `/:id` }}"
-  }
+	// Route normalization (defence-in-depth). The SDK beforeSend hook
+	// should already emit templated routes (e.g. "/user/:id"). These
+	// regex replacements strip numeric and UUID path segments that
+	// slip through, keeping cardinality bounded.
+	stage.template {
+		source   = "route"
+		template = "{{ regexReplaceAll `/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}` .Value `/:uuid` }}"
+	}
 
-  stage.static_labels {
-    values = {
-      source = "faro",
-    }
-  }
+	stage.template {
+		source   = "route"
+		template = "{{ regexReplaceAll `/[0-9]+` .Value `/:id` }}"
+	}
 
-  // Bounded, low-cardinality fields → indexed labels.
-  stage.labels {
-    values = {
-      app     = "",
-      kind    = "",
-      env     = "",
-      browser = "",
-      os      = "",
-      route   = "",
-    }
-  }
+	stage.static_labels {
+		values = {
+			source = "faro",
+		}
+	}
 
-  // High-cardinality identifiers → structured metadata (filterable, not
-  // indexed). Requires Loki >= 3.6 and `allow_structured_metadata: true`.
-  stage.structured_metadata {
-    values = {
-      user_id    = "",
-      session_id = "",
-      trace_id   = "",
-      release    = "",
-    }
-  }
+	// Bounded, low-cardinality fields → indexed labels.
+	stage.labels {
+		values = {
+			app     = "",
+			kind    = "",
+			env     = "",
+			browser = "",
+			os      = "",
+			route   = "",
+		}
+	}
 
-  // Defence-in-depth credential scrubbing. The Faro SDK beforeSend
-  // hook is the primary control; these stages catch anything that
-  // slips through. Bearer allows the full Base64 alphabet (incl.
-  // `+` `/` `=`) plus the URL-safe alternates used by JWTs.
-  stage.replace {
-    expression = "(Bearer\\s+)[A-Za-z0-9._+/=\\-]+"
-    replace    = "$1[REDACTED]"
-  }
-  stage.replace {
-    expression = "(sk-)[A-Za-z0-9]{16,}"
-    replace    = "$1[REDACTED]"
-  }
-  stage.replace {
-    expression = "(eyJ)[A-Za-z0-9._+/=\\-]{16,}"
-    replace    = "$1[REDACTED]"
-  }
+	// High-cardinality identifiers → structured metadata (filterable, not
+	// indexed). Requires Loki >= 3.6 and `allow_structured_metadata: true`.
+	stage.structured_metadata {
+		values = {
+			user_id    = "",
+			session_id = "",
+			trace_id   = "",
+			release    = "",
+		}
+	}
 
-  // Strip common IP-shaped fields so Loki never stores the client
-  // address. Faro payloads and any forwarded headers picked up by the
-  // receiver are both covered by matching the JSON value form.
-  stage.replace {
-    expression = "\"(client_ip|remote_addr|remoteAddr|ip|x_forwarded_for)\":\\s*\"[^\"]+\""
-    replace    = "\"$1\":\"[REDACTED]\""
-  }
+	// Defence-in-depth credential scrubbing. The Faro SDK beforeSend
+	// hook is the primary control; these stages catch anything that
+	// slips through. Bearer allows the full Base64 alphabet (incl.
+	// `+` `/` `=`) plus the URL-safe alternates used by JWTs.
+	stage.replace {
+		expression = "(Bearer\\s+)[A-Za-z0-9._+/=\\-]+"
+		replace    = "$1[REDACTED]"
+	}
 
-  forward_to = [loki.write.loki.receiver]
+	stage.replace {
+		expression = "(sk-)[A-Za-z0-9]{16,}"
+		replace    = "$1[REDACTED]"
+	}
+
+	stage.replace {
+		expression = "(eyJ)[A-Za-z0-9._+/=\\-]{16,}"
+		replace    = "$1[REDACTED]"
+	}
+
+	// Strip common IP-shaped fields so Loki never stores the client
+	// address. Faro payloads and any forwarded headers picked up by the
+	// receiver are both covered by matching the JSON value form.
+	stage.replace {
+		expression = "\"(client_ip|remote_addr|remoteAddr|ip|x_forwarded_for)\":\\s*\"[^\"]+\""
+		replace    = "\"$1\":\"[REDACTED]\""
+	}
+
+	forward_to = [loki.write.loki.receiver]
 }

--- a/stack/docker-compose.yaml
+++ b/stack/docker-compose.yaml
@@ -115,24 +115,79 @@ services:
       start_period: 60s
 
   # ---------------------------------------------------------------------------
-  # Alloy — log collector (replaces Promtail, which is EOL since March 2026)
-  # Scrapes Docker container stdout and ships to Loki.
+  # Alloy — log collector + Faro Web SDK receiver.
+  # Ships Docker stdout to Loki. Also receives browser telemetry on port
+  # 12347 (internal-only) and fans out to Tempo + Loki. Public ingest
+  # at https://obs.bravyr.com/collect is handled by Coolify/Traefik with
+  # basic-auth, CORS, and rate-limiting middlewares (labels below).
   # ---------------------------------------------------------------------------
   alloy:
     image: grafana/alloy:v1.14.0
     container_name: bravyr_alloy
     restart: unless-stopped
     command: ["run", "/etc/alloy/config.alloy", "--storage.path=/var/lib/alloy/data"]
+    environment:
+      FARO_ALLOWED_ORIGINS: "${FARO_ALLOWED_ORIGINS:?FARO_ALLOWED_ORIGINS must be set in .env}"
     volumes:
       - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - alloy_data:/var/lib/alloy/data
+    ports:
+      # Loopback-only so local smoke tests can curl the Faro receiver
+      # without Traefik. Coolify deploys reach Alloy via the Docker
+      # bridge (container name), so this mapping has no production effect.
+      - "127.0.0.1:12347:12347"
     networks:
       - monitoring
     depends_on:
       loki:
         condition: service_started
+      otel-collector:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:12345/-/ready || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    labels:
+      # Coolify/Traefik ingress for the Faro receiver. Coolify's UI still
+      # manages the FQDN → service port mapping (obs.bravyr.com → 12347),
+      # but the middleware chain below is not expressible in the UI.
+      traefik.enable: "true"
+      traefik.http.services.faro.loadbalancer.server.port: "12347"
+
+      traefik.http.routers.faro.rule: "Host(`${FARO_PUBLIC_HOST:-obs.bravyr.com}`) && PathPrefix(`/collect`)"
+      traefik.http.routers.faro.entrypoints: "https"
+      traefik.http.routers.faro.tls: "true"
+      traefik.http.routers.faro.middlewares: "faro-auth@docker,faro-ratelimit@docker,faro-bodysize@docker,faro-security-headers@docker"
+
+      # Basic-auth middleware. FARO_BASIC_AUTH_HTPASSWD must be a bcrypt
+      # htpasswd line (e.g. `faro:$2y$05$…`). Generate with:
+      #   htpasswd -nbB faro "$FARO_APP_KEY"
+      # Dollar signs are doubled in the env var to survive compose interpolation.
+      traefik.http.middlewares.faro-auth.basicauth.users: "${FARO_BASIC_AUTH_HTPASSWD:?FARO_BASIC_AUTH_HTPASSWD must be set in .env}"
+      traefik.http.middlewares.faro-auth.basicauth.removeheader: "true"
+      traefik.http.middlewares.faro-auth.basicauth.realm: "bravyr-obs"
+
+      # Rate limit: 20 req/s sustained, 100 req/s burst, per source IP.
+      traefik.http.middlewares.faro-ratelimit.ratelimit.average: "20"
+      traefik.http.middlewares.faro-ratelimit.ratelimit.burst: "100"
+      traefik.http.middlewares.faro-ratelimit.ratelimit.sourcecriterion.ipstrategy.depth: "1"
+
+      # 1 MB body cap. memRequestBodyBytes spools beyond 64 KB to disk
+      # instead of holding the whole buffer in RAM, blunting memory
+      # amplification from large or slow-loris POSTs.
+      traefik.http.middlewares.faro-bodysize.buffering.maxrequestbodybytes: "1048576"
+      traefik.http.middlewares.faro-bodysize.buffering.memrequestbodybytes: "65536"
+
+      # HSTS + no sniff + referrer policy for the ingest domain.
+      traefik.http.middlewares.faro-security-headers.headers.stsseconds: "31536000"
+      traefik.http.middlewares.faro-security-headers.headers.stsincludesubdomains: "true"
+      traefik.http.middlewares.faro-security-headers.headers.stspreload: "true"
+      traefik.http.middlewares.faro-security-headers.headers.contenttypenosniff: "true"
+      traefik.http.middlewares.faro-security-headers.headers.referrerpolicy: "no-referrer"
 
   # ---------------------------------------------------------------------------
   # Grafana — dashboards wired to Prometheus, Tempo, and Loki

--- a/stack/grafana/dashboards/frontend-rum.json
+++ b/stack/grafana/dashboards/frontend-rum.json
@@ -1,0 +1,559 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_LOKI",
+      "label": "Loki",
+      "type": "datasource",
+      "pluginId": "loki",
+      "pluginName": "Loki"
+    },
+    {
+      "name": "DS_TEMPO",
+      "label": "Tempo",
+      "type": "datasource",
+      "pluginId": "tempo",
+      "pluginName": "Tempo"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "12.0.0" },
+    { "type": "datasource", "id": "loki", "name": "Loki", "version": "1.0.0" },
+    { "type": "datasource", "id": "tempo", "name": "Tempo", "version": "1.0.0" },
+    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
+    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
+    { "type": "panel", "id": "piechart", "name": "Pie chart", "version": "" },
+    { "type": "panel", "id": "table", "name": "Table", "version": "" }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Real-user monitoring for frontend apps instrumented with the Grafana Faro Web SDK. Data sourced from Loki stream {source=\"faro\"} and Tempo traces.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+      "description": "Page loads over the selected window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+          "expr": "sum(count_over_time({source=\"faro\", app=~\"$app\", env=~\"$env\", kind=\"event\"} | json | name=\"page_load\" [$__range]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Page loads",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+      "description": "Distinct sessions over the selected window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+          "expr": "count(count by (session_id) ({source=\"faro\", app=~\"$app\", env=~\"$env\"} | json | session_id != \"\"))",
+          "queryType": "instant",
+          "refId": "A"
+        }
+      ],
+      "title": "Distinct sessions",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+      "description": "JS exceptions captured over the selected window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+          "expr": "sum(count_over_time({source=\"faro\", app=~\"$app\", env=~\"$env\", kind=\"exception\"} [$__range]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "JS exceptions",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+      "description": "Exception rate per minute.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 5 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+          "expr": "sum(rate({source=\"faro\", app=~\"$app\", env=~\"$env\", kind=\"exception\"}[5m])) * 60",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Exceptions / min",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 101,
+      "title": "Core Web Vitals",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+      "description": "Largest Contentful Paint — p75 by route.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "ms",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 2500 },
+              { "color": "red", "value": 4000 }
+            ]
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 6 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+          "expr": "quantile_over_time(0.75, {source=\"faro\", app=~\"$app\", env=~\"$env\", kind=\"measurement\"} | json | type=\"largest_contentful_paint\" | unwrap value [$__rate_interval]) by (route)",
+          "legendFormat": "{{route}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "LCP p75",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+      "description": "Interaction to Next Paint — p75 by route.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "ms",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 200 },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "unit": "ms"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 6 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+          "expr": "quantile_over_time(0.75, {source=\"faro\", app=~\"$app\", env=~\"$env\", kind=\"measurement\"} | json | type=\"interaction_to_next_paint\" | unwrap value [$__rate_interval]) by (route)",
+          "legendFormat": "{{route}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "INP p75",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+      "description": "Cumulative Layout Shift — p75 by route.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisLabel": "score",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.1 },
+              { "color": "red", "value": 0.25 }
+            ]
+          },
+          "unit": "none"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 6 },
+      "id": 7,
+      "options": {
+        "legend": { "calcs": ["mean"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+          "expr": "quantile_over_time(0.75, {source=\"faro\", app=~\"$app\", env=~\"$env\", kind=\"measurement\"} | json | type=\"cumulative_layout_shift\" | unwrap value [$__rate_interval]) by (route)",
+          "legendFormat": "{{route}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "CLS p75",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 102,
+      "title": "Errors",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+      "description": "Recent exceptions with links to the originating Tempo trace.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "inspect": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "trace_id" },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open in Tempo",
+                    "url": "/explore?left=%7B%22datasource%22:%22${datasource_tempo}%22,%22queries%22:%5B%7B%22query%22:%22${__value.raw}%22,%22queryType%22:%22traceql%22%7D%5D%7D"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 15 },
+      "id": 8,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+          "expr": "{source=\"faro\", app=~\"$app\", env=~\"$env\", kind=\"exception\"} | json",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Recent exceptions",
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
+      "id": 103,
+      "title": "Breakdown",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+      "description": "Sessions by browser.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } }
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 28 },
+      "id": 9,
+      "options": {
+        "displayLabels": ["percent"],
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "values": ["value"] },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+          "expr": "sum by (browser) (count_over_time({source=\"faro\", app=~\"$app\", env=~\"$env\"} [$__range]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "By browser",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+      "description": "Sessions by OS.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } }
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 28 },
+      "id": 10,
+      "options": {
+        "displayLabels": ["percent"],
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "values": ["value"] },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+          "expr": "sum by (os) (count_over_time({source=\"faro\", app=~\"$app\", env=~\"$env\"} [$__range]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "By OS",
+      "type": "piechart"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+      "description": "Exceptions by route.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "hideFrom": { "legend": false, "tooltip": false, "viz": false } }
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 28 },
+      "id": 11,
+      "options": {
+        "displayLabels": ["percent"],
+        "legend": { "displayMode": "table", "placement": "right", "showLegend": true, "values": ["value"] },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["sum"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+          "expr": "sum by (route) (count_over_time({source=\"faro\", app=~\"$app\", env=~\"$env\", kind=\"exception\"} [$__range]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Exceptions by route",
+      "type": "piechart"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["bravyr-obs", "frontend", "rum", "faro"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Loki", "value": "Loki" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Loki",
+        "multi": false,
+        "name": "datasource_loki",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": { "selected": false, "text": "Tempo", "value": "Tempo" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Tempo",
+        "multi": false,
+        "name": "datasource_tempo",
+        "options": [],
+        "query": "tempo",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+        "definition": "label_values({source=\"faro\"}, app)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "App",
+        "multi": true,
+        "name": "app",
+        "options": [],
+        "query": { "label": "app", "refId": "LokiVariableQueryEditor-VariableQuery", "stream": "{source=\"faro\"}", "type": 1 },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": { "type": "loki", "uid": "${datasource_loki}" },
+        "definition": "label_values({source=\"faro\"}, env)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Environment",
+        "multi": true,
+        "name": "env",
+        "options": [],
+        "query": { "label": "env", "refId": "LokiVariableQueryEditor-VariableQuery", "stream": "{source=\"faro\"}", "type": 1 },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Frontend RUM (Faro)",
+  "uid": "bravyr-frontend-rum",
+  "version": 1,
+  "weekStart": ""
+}

--- a/stack/loki/config.yaml
+++ b/stack/loki/config.yaml
@@ -27,9 +27,10 @@ schema_config:
         period: 24h
 
 limits_config:
-  retention_period: 72h
-  ingestion_burst_size_mb: 16
-  ingestion_rate_mb: 8
+  retention_period: 336h   # 14 days
+  ingestion_burst_size_mb: 64
+  ingestion_rate_mb: 32
+  allow_structured_metadata: true
 
 compactor:
   working_directory: /loki/compactor

--- a/stack/scripts/smoke-faro.sh
+++ b/stack/scripts/smoke-faro.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Smoke test for the Grafana Faro ingest pipeline.
+#
+# Prerequisites: the full stack must be running (docker compose up from
+# stack/). The test posts a synthetic Faro payload to the local Alloy
+# receiver (bypassing Traefik) and asserts the resulting span surfaces
+# in Tempo and the log entry surfaces in Loki.
+#
+# Usage: stack/scripts/smoke-faro.sh
+
+set -euo pipefail
+
+ALLOY_URL="${ALLOY_URL:-http://127.0.0.1:12347/collect}"
+TEMPO_URL="${TEMPO_URL:-http://127.0.0.1:3200}"
+LOKI_URL="${LOKI_URL:-http://127.0.0.1:3100}"
+WAIT_SECONDS="${WAIT_SECONDS:-5}"
+
+trace_id="$(openssl rand -hex 16)"
+span_id="$(openssl rand -hex 8)"
+now_ns="$(date +%s)000000000"
+end_ns="$(( now_ns + 1000000000 ))"
+
+payload=$(cat <<EOF
+{
+  "meta": {
+    "app":     {"name":"socialup-web","version":"0.0.0-smoke","environment":"development"},
+    "browser": {"name":"Chrome","os":"macOS","mobile":false,"userAgent":"smoke"},
+    "session": {"id":"smoke-session"},
+    "user":    {"id":"smoke-user"},
+    "view":    {"name":"/smoke"},
+    "trace":   {"trace_id":"${trace_id}","span_id":"${span_id}"}
+  },
+  "logs":  [{"timestamp":"$(date -u +%FT%TZ)","level":"info","message":"smoke-test","kind":"log"}],
+  "traces": {
+    "resourceSpans": [{
+      "resource": {"attributes":[{"key":"service.name","value":{"stringValue":"socialup-web"}}]},
+      "scopeSpans": [{"spans":[{
+        "traceId":"${trace_id}","spanId":"${span_id}",
+        "name":"smoke-test",
+        "startTimeUnixNano":"${now_ns}","endTimeUnixNano":"${end_ns}",
+        "kind":1,"status":{}
+      }]}]
+    }]
+  }
+}
+EOF
+)
+
+echo "POST ${ALLOY_URL} (trace_id=${trace_id})"
+status=$(curl -s -o /tmp/faro-smoke.resp -w "%{http_code}" \
+  -X POST "${ALLOY_URL}" \
+  -H "Content-Type: application/json" \
+  -H "Origin: http://localhost:5173" \
+  --data "${payload}")
+if [[ "${status}" != "200" && "${status}" != "204" ]]; then
+  echo "  FAIL — expected 200/204, got ${status}"
+  cat /tmp/faro-smoke.resp
+  exit 1
+fi
+echo "  OK (${status})"
+
+echo "Waiting ${WAIT_SECONDS}s for ingestion..."
+sleep "${WAIT_SECONDS}"
+
+echo "GET ${TEMPO_URL}/api/traces/${trace_id}"
+if ! curl -sf "${TEMPO_URL}/api/traces/${trace_id}" | grep -q "${span_id}"; then
+  echo "  FAIL — trace not found in Tempo"
+  exit 1
+fi
+echo "  OK"
+
+echo "GET ${LOKI_URL}/loki/api/v1/query_range {source=faro}"
+start_ns=$(( now_ns - 60000000000 ))
+end_query_ns=$(( now_ns + 60000000000 ))
+response=$(curl -sfG "${LOKI_URL}/loki/api/v1/query_range" \
+  --data-urlencode 'query={source="faro"}' \
+  --data-urlencode "start=${start_ns}" \
+  --data-urlencode "end=${end_query_ns}")
+count=$(printf '%s' "${response}" | grep -c "smoke-test" || true)
+if [[ "${count}" == "0" ]]; then
+  echo "  FAIL — 'smoke-test' not found in Loki within window"
+  exit 1
+fi
+echo "  OK (${count} match)"
+
+echo
+echo "All checks passed."

--- a/stack/tempo/config.yaml
+++ b/stack/tempo/config.yaml
@@ -17,13 +17,13 @@ distributor:
           endpoint: "0.0.0.0:4318"
 
 ingester:
-  max_block_bytes: 1_000_000
+  max_block_bytes: 100_000_000
   max_block_duration: 5m
   complete_block_timeout: 15m
 
 compactor:
   compaction:
-    block_retention: 72h   # keep 3 days of traces locally
+    block_retention: 336h   # keep 14 days of traces locally
 
 storage:
   trace:


### PR DESCRIPTION
## Summary

- Adds `faro.receiver` to Alloy for Grafana Faro Web SDK clients (web-vitals, JS errors, distributed browser→Go traces); traces fan out through the existing OTel Collector to Tempo, logs land in a dedicated `{source="faro"}` Loki pipeline.
- Public ingest at `https://obs.bravyr.com/collect` routed by Coolify/Traefik with basic-auth (bcrypt), strict CORS allowlist, 20 r/s rate limit (100 burst), 1 MB body cap with 64 KB in-memory spool, and HSTS. Alloy backstops the edge rate limit.
- Dedicated Loki pipeline: bounded fields (`app`, `kind`, `env`, `browser`, `os`, normalized `route`) become indexed labels; unbounded identifiers (`user_id`, `session_id`, `trace_id`, `release`) stay in structured metadata. Defence-in-depth regex scrubs `Bearer …`, `sk-…`, `eyJ…` prefixes and IP-shaped fields before the Loki write.
- Retention bumped to 14d on Tempo + Loki, Tempo `max_block_bytes` to 100 MB, Loki ingestion to 32/64 MB/s with structured-metadata enabled.
- New `Frontend RUM (Faro)` Grafana dashboard: page loads, distinct sessions, JS exceptions, LCP/INP/CLS p75 by route, browser/OS breakdowns, and a Tempo-linked exception table.
- Adds `alloy-fmt` CI job, `stack/scripts/smoke-faro.sh` end-to-end smoke test, and an Alloy `/-/ready` healthcheck.

Plan: [`docs/plans/009-frontend-observability.md`](docs/plans/009-frontend-observability.md).

## Test plan

- [x] `make lint` — `0 issues`
- [x] `make test` — all packages pass
- [x] `make swagger` — library has no swagger spec (expected)
- [ ] Deploy to staging in Coolify; verify Let's Encrypt cert provisions for `obs.bravyr.com`
- [ ] Run `stack/scripts/smoke-faro.sh` against staging: payload returns 200, span appears in Tempo, log appears in Loki with `source=faro`
- [ ] Negative tests against staging:
  - [ ] POST without `Authorization` → `401`
  - [ ] POST with valid auth + disallowed `Origin` → CORS reject
  - [ ] POST body > 1 MB → `413`
  - [ ] Exceed 20 r/s sustained → `429`
- [ ] Load `Frontend RUM (Faro)` dashboard in Grafana and confirm template variables populate once telemetry arrives
- [ ] Open a trace in Tempo and confirm the browser span links to a downstream Go handler span

## Follow-up issues

Created under the deferred-work policy — Loki per-stream retention split, disk-growth alerts, Traefik middleware integration tests, token-rotation runbook, private source-map symbolicator pipeline, Loki ruler → Prometheus recording rules for web-vitals, and the socialup-side Faro SDK integration PR.