### PR TITLE
fix(stack): pin Grafana Traefik network to fix Coolify 504

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `stack/.env.example` — `GF_SERVER_ROOT_URL` field so Grafana's root URL can be set to the public FQDN behind Coolify/Traefik (defaults to `http://localhost:3000` for local dev)
 - `redistrace` sub-package for Redis command span instrumentation via redisotel (`db.statement` off by default)
 - `temporaltrace` sub-package for Temporal workflow/activity span instrumentation via the Temporal OTel contrib interceptor
 - Prometheus bearer token auth for `/metrics` scraping via `INTERNAL_API_KEY` env var
@@ -35,6 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `stack/grafana/provisioning/datasources/datasources.yaml` — replaced Seq datasource with Loki datasource
 - `stack/.env.example` — removed `SEQ_API_KEY` field
 - `stack/README.md` — updated service list, architecture diagram, and quick-start instructions to reflect Loki + Promtail replacing Seq
+- `stack/docker-compose.yaml` — Grafana `GF_SERVER_ROOT_URL` is now env-driven (`${GF_SERVER_ROOT_URL:-http://localhost:3000}`) instead of hardcoded to localhost
+
+### Fixed
+
+- `stack/docker-compose.yaml` — pin `traefik.docker.network: coolify` on the Grafana service. Under Coolify, Grafana attaches to multiple Docker networks; without this label Traefik could resolve Grafana to an unroutable network IP, causing a 504 Gateway Timeout when accessing the dashboard through its public domain
 
 ### Removed
 

--- a/stack/.env.example
+++ b/stack/.env.example
@@ -5,6 +5,11 @@
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=CHANGEME
 
+# Public FQDN Grafana is served from. Required behind Coolify/Traefik or
+# redirects and asset links break. Leave unset for local dev (defaults to
+# http://localhost:3000). Example for staging:
+GF_SERVER_ROOT_URL=https://grafana-staging.socialup.bravyr.com
+
 # Internal API key for Prometheus to scrape /metrics endpoints.
 # Must match INTERNAL_API_KEY set in the socialup-api Coolify env vars.
 INTERNAL_API_KEY=CHANGEME

--- a/stack/docker-compose.yaml
+++ b/stack/docker-compose.yaml
@@ -145,7 +145,7 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD must be set in .env}"
       GF_SECURITY_ADMIN_USER: "${GRAFANA_ADMIN_USER:-admin}"
       GF_USERS_ALLOW_SIGN_UP: "false"
-      GF_SERVER_ROOT_URL: "http://localhost:3000"
+      GF_SERVER_ROOT_URL: "${GF_SERVER_ROOT_URL:-http://localhost:3000}"
       GF_ANALYTICS_REPORTING_ENABLED: "false"
     volumes:
       - grafana_data:/var/lib/grafana
@@ -168,3 +168,9 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    labels:
+      # Grafana attaches to multiple Docker networks under Coolify (coolify +
+      # resource net + monitoring). Without this, Traefik may resolve Grafana
+      # to a network IP it cannot route to -> 504 Gateway Timeout. Pin the
+      # network Traefik must use to reach the container.
+      traefik.docker.network: "coolify"


### PR DESCRIPTION
## Summary

- Pin `traefik.docker.network: coolify` on the Grafana service. Under Coolify, Grafana attaches to multiple Docker networks (`coolify` + resource net + `monitoring`). Without this label, Traefik may resolve Grafana to an unroutable network IP, returning a **504 Gateway Timeout** on the public domain.
- Make `GF_SERVER_ROOT_URL` env-driven (`${GF_SERVER_ROOT_URL:-http://localhost:3000}`) so the public FQDN can be set per deployment without breaking local dev.
- Document `GF_SERVER_ROOT_URL` in `stack/.env.example`.

## Why

Staging Grafana (`grafana-staging.socialup.bravyr.com`) returned 504 while the container itself was healthy. Root cause was Traefik targeting a non-coolify network IP on the multi-homed Grafana container.

## Test plan

- [ ] Set `GF_SERVER_ROOT_URL` in Coolify env vars for the obs stack
- [ ] Reload Compose File + Redeploy in Coolify
- [ ] Confirm Grafana service shows `traefik.docker.network=coolify`
- [ ] Hit `https://grafana-staging.socialup.bravyr.com` — loads, no 504
- [ ] `docker exec coolify-proxy wget -qO- http://<grafana-container>:3000/api/health` returns `{"database":"ok"}`